### PR TITLE
refactor log4j-core-test to junit 5

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInTest.java
@@ -16,15 +16,18 @@
  */
 package org.apache.logging.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import org.apache.logging.log4j.MarkerManager.Log4jMarker;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link MarkerMixIn}.
@@ -36,7 +39,7 @@ public abstract class MarkerMixInTest {
     private ObjectReader reader;
     private ObjectWriter writer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final ObjectMapper log4jObjectMapper = newObjectMapper();
         writer = log4jObjectMapper.writer();
@@ -50,9 +53,9 @@ public abstract class MarkerMixInTest {
     public void testNameOnly() throws IOException {
         final Marker expected = MarkerManager.getMarker("A");
         final String str = writeValueAsString(expected);
-        Assert.assertFalse(str.contains("parents"));
+        assertFalse(str.contains("parents"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -61,9 +64,9 @@ public abstract class MarkerMixInTest {
         final Marker parent = MarkerManager.getMarker("PARENT_MARKER");
         expected.addParents(parent);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER"));
+        assertTrue(str.contains("PARENT_MARKER"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**
@@ -85,9 +88,9 @@ public abstract class MarkerMixInTest {
         expected.addParents(parent1);
         expected.addParents(parent2);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER1"));
-        Assert.assertTrue(str.contains("PARENT_MARKER2"));
+        assertTrue(str.contains("PARENT_MARKER1"));
+        assertTrue(str.contains("PARENT_MARKER2"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +50,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue("Logger is of type " + Holder.LOGGER.getClass().getName(), Holder.LOGGER instanceof TestLogger);
+            assertTrue(
+                    Holder.LOGGER instanceof TestLogger,
+                    "Logger is of type " + Holder.LOGGER.getClass().getName());
             if (((TestLogger) Holder.LOGGER).getEntries().isEmpty()) {
                 System.out.println("Logger contains no messages");
             }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompactFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompactFileAppenderTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,18 +26,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests a "compact" XML file, no extra spaces or end of lines.
  */
-@Category(Layouts.Xml.class)
+@Tag("Layouts.Xml")
 public class XmlCompactFileAppenderTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "XmlCompactFileAppenderTest.xml");
     }
@@ -57,21 +56,21 @@ public class XmlCompactFileAppenderTest {
         } finally {
             file.delete();
         }
-        assertNotNull("line1", line1);
+        assertNotNull(line1, "line1");
         final String msg1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg1 + ']', line1.contains(msg1));
+        assertTrue(line1.contains(msg1), "line1 incorrect: [" + line1 + "], does not contain: [" + msg1 + ']');
 
         final String msg2 = "<Events xmlns=\"http://logging.apache.org/log4j/2.0/events\">";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg2 + ']', line1.contains(msg2));
+        assertTrue(line1.contains(msg2), "line1 incorrect: [" + line1 + "], does not contain: [" + msg2 + ']');
 
         final String msg3 = "<Event ";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg3 + ']', line1.contains(msg3));
+        assertTrue(line1.contains(msg3), "line1 incorrect: [" + line1 + "], does not contain: [" + msg3 + ']');
 
         final String msg4 = logMsg;
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg4 + ']', line1.contains(msg4));
+        assertTrue(line1.contains(msg4), "line1 incorrect: [" + line1 + "], does not contain: [" + msg4 + ']');
 
         final String location = "testFlushAtEndOfBatch";
-        assertTrue("no location", !line1.contains(location));
+        assertTrue(!line1.contains(location), "no location");
 
         assertTrue(line1.indexOf('\r') == -1);
         assertTrue(line1.indexOf('\n') == -1);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlFileAppenderTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -26,18 +26,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests a "complete" XML file a.k.a. a well-formed XML file.
  */
-@Category(Layouts.Xml.class)
+@Tag("Layouts.Xml")
 public class XmlFileAppenderTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "XmlFileAppenderTest.xml");
     }
@@ -65,11 +64,11 @@ public class XmlFileAppenderTest {
 
         for (int i = 0; i < expect.length; i++) {
             assertTrue(
-                    "Expected line " + i + " to contain " + expect[i] + " but got: " + lines.get(i),
-                    lines.get(i).contains(expect[i]));
+                    lines.get(i).contains(expect[i]),
+                    "Expected line " + i + " to contain " + expect[i] + " but got: " + lines.get(i));
         }
 
         final String location = "testFlushAtEndOfBatch";
-        assertTrue("no location", !lines.get(0).contains(location));
+        assertTrue(!lines.get(0).contains(location), "no location");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/DriverManagerH2ConnectionSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/DriverManagerH2ConnectionSourceTest.java
@@ -20,8 +20,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.test.appender.db.jdbc.JdbcH2TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
 
@@ -40,7 +40,7 @@ public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
                 .build();
         // @formatter:on
         try (final Connection conn = source.getConnection()) {
-            Assert.assertFalse(conn.isClosed());
+            Assertions.assertFalse(conn.isClosed());
         }
     }
 
@@ -54,7 +54,7 @@ public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
                 .build();
         // @formatter:on
         try (final Connection conn = source.getConnection()) {
-            Assert.assertFalse(conn.isClosed());
+            Assertions.assertFalse(conn.isClosed());
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaManagerProducerThreadLeakTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaManagerProducerThreadLeakTest.java
@@ -19,9 +19,8 @@ package org.apache.logging.log4j.core.appender.mom.kafka;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.Test;
  *
  * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-2916">LOG4J2-2916</a>
  */
-@Category(Appenders.Kafka.class)
+@Tag("Appenders.Kafka")
 @LoggerContextSource("KafkaManagerProducerThreadLeakTest.xml")
 class KafkaManagerProducerThreadLeakTest {
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppenderTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.logging.log4j.core.appender.nosql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NoSqlAppenderTest {
 
     @Mock
@@ -35,18 +35,18 @@ public class NoSqlAppenderTest {
     public void testNoProvider() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("myName01", null, null, null, null);
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
     public void testProvider() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("myName01", null, null, null, provider);
 
-        assertNotNull("The appender should not be null.", appender);
+        assertNotNull(appender, "The appender should not be null.");
         assertEquals(
-                "The toString value is not correct.",
                 "myName01{ manager=noSqlManager{ description=myName01, bufferSize=0, provider=" + provider + " } }",
-                appender.toString());
+                appender.toString(),
+                "The toString value is not correct.");
 
         appender.stop();
     }
@@ -55,12 +55,12 @@ public class NoSqlAppenderTest {
     public void testProviderBuffer() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("anotherName02", null, null, "25", provider);
 
-        assertNotNull("The appender should not be null.", appender);
+        assertNotNull(appender, "The appender should not be null.");
         assertEquals(
-                "The toString value is not correct.",
                 "anotherName02{ manager=noSqlManager{ description=anotherName02, bufferSize=25, provider=" + provider
                         + " } }",
-                appender.toString());
+                appender.toString(),
+                "The toString value is not correct.");
 
         appender.stop();
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.DirectoryStream;
@@ -81,13 +81,14 @@ public class RollingAppenderOnStartupTest {
                 if (path.toFile().getName().startsWith(ROLLED)) {
                     rolled = true;
                     final List<String> lines = Files.readAllLines(path);
-                    assertTrue("No messages in " + path.toFile().getName(), lines.size() > 0);
                     assertTrue(
-                            "Missing message for " + path.toFile().getName(),
-                            lines.get(0).startsWith(PREFIX + "1"));
+                            lines.size() > 0, "No messages in " + path.toFile().getName());
+                    assertTrue(
+                            lines.get(0).startsWith(PREFIX + "1"),
+                            "Missing message for " + path.toFile().getName());
                 }
             }
         }
-        assertTrue("File did not roll", rolled);
+        assertTrue(rolled, "File did not roll");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderAccessTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderAccessTest.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderAccessTest {
 
@@ -49,8 +49,8 @@ public class RollingFileAppenderAccessTest {
             final RollingFileManager manager = appender.getManager();
             // Since the RolloverStrategy and TriggeringPolicy are immutable, we could also use generics to type their
             // access.
-            Assert.assertNotNull(manager.getRolloverStrategy());
-            Assert.assertNotNull(manager.getTriggeringPolicy());
+            Assertions.assertNotNull(manager.getRolloverStrategy());
+            Assertions.assertNotNull(manager.getTriggeringPolicy());
         }
     }
 
@@ -84,8 +84,8 @@ public class RollingFileAppenderAccessTest {
             final RollingFileManager manager = appender.getManager();
             // Since the RolloverStrategy and TriggeringPolicy are immutable, we could also use generics to type their
             // access.
-            Assert.assertNotNull(manager.getRolloverStrategy());
-            Assert.assertNotNull(manager.getTriggeringPolicy());
+            Assertions.assertNotNull(manager.getRolloverStrategy());
+            Assertions.assertNotNull(manager.getTriggeringPolicy());
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderBuilderTest.java
@@ -17,8 +17,8 @@
 package org.apache.logging.log4j.core.appender.rolling;
 
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderBuilderTest {
 
@@ -27,6 +27,6 @@ public class RollingFileAppenderBuilderTest {
      */
     @Test
     public void testDefaultImmediateFlush() {
-        Assert.assertTrue(RollingFileAppender.newBuilder().isImmediateFlush());
+        Assertions.assertTrue(RollingFileAppender.newBuilder().isImmediateFlush());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderLayoutTest.java
@@ -18,15 +18,15 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderLayoutTest {
 
     @Test
     public void testDefaultLayout() throws Exception {
         // @formatter:off
-        Assert.assertNotNull(RollingFileAppender.newBuilder()
+        Assertions.assertNotNull(RollingFileAppender.newBuilder()
                 .setName(RollingFileAppenderLayoutTest.class.getName())
                 .setConfiguration(new DefaultConfiguration())
                 .withFileName("log.txt")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverFilePatternTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverFilePatternTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.regex.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test getEligibleFiles method.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/PathConditionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/PathConditionTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling.action;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
@@ -16,30 +16,32 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test class loading deadlock condition from the LOG4J2-1457
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerClassLoadDeadlockTest {
 
     static final int RING_BUFFER_SIZE = 128;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
         System.setProperty("AsyncLogger.RingBufferSize", String.valueOf(RING_BUFFER_SIZE));
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConsoleTest.xml");
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testClassLoaderDeadlock() throws Exception {
         // touch the class so static init will be called
         final AsyncLoggerClassLoadDeadlock temp = new AsyncLoggerClassLoadDeadlock();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
@@ -51,7 +51,7 @@ public class AsyncLoggerConfigAutoFlushTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
+        assertNotNull(line1, "line1");
         assertTrue(line1.contains(msg), "line1 correct");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,15 +26,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigAutoFlushTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigAutoFlushTest.xml");
     }
@@ -42,7 +41,7 @@ public class AsyncLoggerConfigAutoFlushTest {
     @Test
     public void testFlushAtEndOfBatch() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigAutoFlushTest.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String msg = "Message flushed with immediate flush=false";
@@ -53,6 +52,6 @@ public class AsyncLoggerConfigAutoFlushTest {
         reader.close();
         file.delete();
         assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertTrue(line1.contains(msg), "line1 correct");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -29,18 +29,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.DefaultLogEventFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.AsynchronouslyFormattable;
 import org.apache.logging.log4j.message.Message;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigErrorOnFormat {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j2.enableThreadlocals", "true");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigErrorOnFormat.xml");
@@ -48,7 +47,7 @@ public class AsyncLoggerConfigErrorOnFormat {
         System.setProperty("log4j2.logEventFactory", DefaultLogEventFactory.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty("log4j2.enableThreadlocals");
         System.clearProperty("log4j2.logEventFactory");
@@ -57,7 +56,7 @@ public class AsyncLoggerConfigErrorOnFormat {
     @Test
     public void testError() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigErrorOnFormat.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         log.info(new ThrowsErrorOnFormatMessage());
@@ -71,7 +70,7 @@ public class AsyncLoggerConfigErrorOnFormat {
         file.delete();
 
         assertThat(line1, containsString("Second message"));
-        assertNull("Expected only one line", line2);
+        assertNull(line2, "Expected only one line");
     }
 
     @AsynchronouslyFormattable // Shouldn't call getFormattedMessage early

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,18 +27,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigTest2 {
 
     @Test
     public void testConsecutiveReconfigure() throws Exception {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest2.xml");
         final File file = new File("target", "AsyncLoggerConfigTest2.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String msg = "Message before reconfig";
@@ -57,9 +56,9 @@ public class AsyncLoggerConfigTest2 {
         final String line2 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1 " + line1, line1.contains(msg));
-        assertTrue("line2 " + line2, line2.contains(msg2));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.contains(msg), "line1 " + line1);
+        assertTrue(line2.contains(msg2), "line2 " + line2);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.async;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,16 +27,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigWithAsyncEnabledTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j2.enableThreadlocals", "true");
         System.setProperty("log4j2.contextSelector", AsyncLoggerContextSelector.class.getCanonicalName());
@@ -44,7 +43,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest4.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty("log4j2.enableThreadlocals");
         System.clearProperty("log4j2.contextSelector");
@@ -53,7 +52,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
     @Test
     public void testParametersAreAvailableToLayout() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigTest4.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String format = "Additive logging: {} for the price of {}!";

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorInitialStateTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorInitialStateTest.java
@@ -16,13 +16,12 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerContextSelectorInitialStateTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
@@ -16,16 +16,15 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerContextSelectorTest {
 
     private static final String FQCN = AsyncLoggerContextSelectorTest.class.getName();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerDefaultLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerDefaultLocationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,23 +27,22 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerDefaultLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerDefaultLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -59,7 +58,7 @@ public class AsyncLoggerDefaultLocationTest {
         context.stop();
         assertEquals(1, app.getEvents().size());
         final LogEvent event = app.getEvents().get(0);
-        assertFalse("includeLocation should be false", event.isIncludeLocation());
-        assertNull("Location data should not be present", event.getSource());
+        assertFalse(event.isIncludeLocation(), "includeLocation should be false");
+        assertNull(event.getSource(), "Location data should not be present");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
@@ -63,7 +63,7 @@ public class AsyncLoggerLocationTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
+        assertNotNull(line1, "line1");
         assertTrue(line1.contains(msg), "line1 correct");
 
         final String location = "testAsyncLogWritesToLog";

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,18 +26,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         final File file = new File("target", "AsyncLoggerLocationTest.log");
         file.delete();
@@ -46,7 +45,7 @@ public class AsyncLoggerLocationTest {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -65,9 +64,9 @@ public class AsyncLoggerLocationTest {
         reader.close();
         file.delete();
         assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertTrue(line1.contains(msg), "line1 correct");
 
         final String location = "testAsyncLogWritesToLog";
-        assertTrue("has location", line1.contains(location));
+        assertTrue(line1.contains(location), "has location");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -25,25 +25,24 @@ import java.io.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.DummyNanoClock;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -65,11 +64,11 @@ public class AsyncLoggerTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertNotNull(line1, "line1");
+        assertTrue(line1.contains(msg), "line1 correct");
 
         final String location = "testAsyncLogWritesToLog";
-        assertTrue("no location", !line1.contains(location));
+        assertTrue(!line1.contains(location), "no location");
 
         assertTrue(LogManager.getFactory().isClassLoaderDependent());
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,24 +26,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTestCachedThreadName {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -67,9 +66,9 @@ public class AsyncLoggerTestCachedThreadName {
         // System.out.println(line2);
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1", line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
-        assertTrue("line2", line2.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line1");
+        assertTrue(line2.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line2");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,25 +26,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTestUncachedThreadName {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("AsyncLogger.ThreadNameStrategy", "UNCACHED");
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -68,9 +67,9 @@ public class AsyncLoggerTestUncachedThreadName {
         // System.out.println(line2);
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1", line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
-        assertTrue("line2", line2.endsWith(" INFO c.f.Bar [MODIFIED-THREADNAME]   Async logger msg "));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line1");
+        assertTrue(line2.endsWith(" INFO c.f.Bar [MODIFIED-THREADNAME]   Async logger msg "), "line2");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
@@ -16,23 +16,22 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerThreadNameStrategyTest {
-    @After
+    @AfterEach
     public void after() {
         System.clearProperty("AsyncLogger.ThreadNameStrategy");
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         System.clearProperty("AsyncLogger.ThreadNameStrategy");
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,23 +27,22 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncRootLoggerDefaultLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncRootLoggerDefaultLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -59,7 +58,7 @@ public class AsyncRootLoggerDefaultLocationTest {
         context.stop();
         assertEquals(1, app.getEvents().size());
         final LogEvent event = app.getEvents().get(0);
-        assertFalse("includeLocation should be false", event.isIncludeLocation());
-        assertNull("Location data should not be present", event.getSource());
+        assertFalse(event.isIncludeLocation(), "includeLocation should be false");
+        assertNull(event.getSource(), "Location data should not be present");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
@@ -17,20 +17,19 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.YieldingWaitStrategy;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncWaitStrategyFactoryConfigTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
@@ -17,23 +17,22 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(
@@ -41,7 +40,7 @@ public class AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest {
                 "AsyncWaitStrategyIncorrectFactoryConfigGlobalLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
         System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DefaultAsyncQueueFullPolicyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DefaultAsyncQueueFullPolicyTest.java
@@ -16,17 +16,16 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the DefaultAsyncQueueFullPolicy class.
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class DefaultAsyncQueueFullPolicyTest {
 
     private static long currentThreadId() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NestedLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NestedLoggerConfigTest.java
@@ -16,38 +16,29 @@
  */
 package org.apache.logging.log4j.core.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for LoggerConfig hierarchies.
  */
-@RunWith(Parameterized.class)
 public class NestedLoggerConfigTest {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static List<String> data() throws IOException {
-        return ImmutableList.of("logger-config/LoggerConfig/", "logger-config/AsyncLoggerConfig/");
+    public static Stream<String> data() {
+        return Stream.of("logger-config/LoggerConfig/", "logger-config/AsyncLoggerConfig/");
     }
 
-    private final String prefix;
-
-    public NestedLoggerConfigTest(final String prefix) {
-        this.prefix = prefix;
-    }
-
-    @Test
-    public void testInheritParentDefaultLevel() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void testInheritParentDefaultLevel(String prefix) throws IOException {
         final Configuration configuration = loadConfiguration(prefix + "default-level.xml");
         try {
             assertEquals(Level.ERROR, configuration.getLoggerConfig("com.foo").getLevel());
@@ -56,8 +47,9 @@ public class NestedLoggerConfigTest {
         }
     }
 
-    @Test
-    public void testInheritParentLevel() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void testInheritParentLevel(String prefix) throws IOException {
         final Configuration configuration = loadConfiguration(prefix + "inherit-level.xml");
         try {
             assertEquals(Level.TRACE, configuration.getLoggerConfig("com.foo").getLevel());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistryTest.java
@@ -16,19 +16,22 @@
  */
 package org.apache.logging.log4j.core.config.plugins.convert;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TypeConverterRegistryTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFindNullConverter() {
-        TypeConverterRegistry.getInstance().findCompatibleConverter(null);
+        assertThrows(NullPointerException.class, () -> {
+            TypeConverterRegistry.getInstance().findCompatibleConverter(null);
+        });
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.logging.log4j.core.config.plugins.processor;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnit4.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginCacheTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
@@ -17,29 +17,29 @@
 package org.apache.logging.log4j.core.config.plugins.processor;
 
 import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Map;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAliases;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnit4.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginProcessorTest {
 
     private static final PluginCache pluginCache = new PluginCache();
 
     private final Plugin p = FakePlugin.class.getAnnotation(Plugin.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception {
         final Enumeration<URL> resources =
                 PluginProcessor.class.getClassLoader().getResources(PluginProcessor.PLUGIN_CACHE_FILE);
@@ -48,10 +48,10 @@ public class PluginProcessorTest {
 
     @Test
     public void testTestCategoryFound() throws Exception {
-        assertNotNull("No plugin annotation on FakePlugin.", p);
+        assertNotNull(p, "No plugin annotation on FakePlugin.");
         final Map<String, PluginEntry> testCategory = pluginCache.getCategory(p.category());
-        assertNotEquals("No plugins were found.", 0, pluginCache.size());
-        assertNotNull("The category '" + p.category() + "' was not found.", testCategory);
+        assertNotEquals(0, pluginCache.size(), "No plugins were found.");
+        assertNotNull(testCategory, "The category '" + p.category() + "' was not found.");
         assertFalse(testCategory.isEmpty());
     }
 
@@ -71,7 +71,7 @@ public class PluginProcessorTest {
     }
 
     private void verifyFakePluginEntry(final String name, final PluginEntry fake) {
-        assertNotNull("The plugin '" + toRootLowerCase(name) + "' was not found.", fake);
+        assertNotNull(fake, "The plugin '" + toRootLowerCase(name) + "' was not found.");
         assertEquals(FakePlugin.class.getName(), fake.getClassName());
         assertEquals(toRootLowerCase(name), fake.getKey());
         assertEquals(Plugin.EMPTY, p.elementType());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429Test.java
@@ -25,12 +25,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class JacksonIssue429Test {
 
     @SuppressWarnings("serial")
@@ -73,9 +72,9 @@ public class JacksonIssue429Test {
     public void testStackTraceElementWithCustom() throws Exception {
         // first, via bean that contains StackTraceElement
         final StackTraceBean bean = MAPPER.readValue(aposToQuotes("{'Location':'foobar'}"), StackTraceBean.class);
-        Assert.assertNotNull(bean);
-        Assert.assertNotNull(bean.location);
-        Assert.assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
+        Assertions.assertNotNull(bean);
+        Assertions.assertNotNull(bean.location);
+        Assertions.assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
 
         // and then directly, iff registered
         final ObjectMapper mapper = new ObjectMapper();
@@ -86,7 +85,7 @@ public class JacksonIssue429Test {
         final StackTraceElement elem = mapper.readValue(
                 aposToQuotes("{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}"),
                 StackTraceElement.class);
-        Assert.assertNotNull(elem);
-        Assert.assertEquals(StackTraceBean.NUM, elem.getLineNumber());
+        Assertions.assertNotNull(elem);
+        Assertions.assertEquals(StackTraceBean.NUM, elem.getLineNumber());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
@@ -22,12 +22,11 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class StackTraceElementMixInTest {
 
     @Test
@@ -53,7 +52,7 @@ public class StackTraceElementMixInTest {
                 new StackTraceElement("package.SomeClass", "someMethod", "SomeClass.java", 123);
         final String s = mapper.writeValueAsString(expected);
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
@@ -76,7 +75,7 @@ public class StackTraceElementMixInTest {
         final String s = this.aposToQuotes(
                 "{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}");
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
@@ -91,6 +90,6 @@ public class StackTraceElementMixInTest {
         final String s = this.aposToQuotes(
                 "{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}");
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/LogEventParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/LogEventParserTest.java
@@ -19,8 +19,8 @@ package org.apache.logging.log4j.core.parser;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import org.apache.logging.log4j.Level;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
@@ -16,31 +16,19 @@
  */
 package org.apache.logging.log4j.core.pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *  Unit tests for {@link NameAbbreviator} which abbreviates dot-delimited strings such as logger and class names.
  */
-@RunWith(Parameterized.class)
 public class NameAbbreviatorTest {
 
-    private final String pattern;
-    private final String expected;
-
-    public NameAbbreviatorTest(final String pattern, final String expected) {
-        this.pattern = pattern;
-        this.expected = expected;
-    }
-
-    @Parameterized.Parameters(name = "pattern=\"{0}\", expected={1}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
+    public static Stream<Object[]> data() {
+        return Stream.of(new Object[][] {
             // { pattern, expected }
             {"0", "NameAbbreviatorTest"},
             {"1", "NameAbbreviatorTest"},
@@ -56,18 +44,20 @@ public class NameAbbreviatorTest {
         });
     }
 
-    @Test
-    public void testAbbreviatorPatterns() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatterns(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final StringBuilder destination = new StringBuilder();
         abbreviator.abbreviate(this.getClass().getName(), destination);
         final String actual = destination.toString();
         assertEquals(expected, actual);
     }
 
-    @Test
-    public void testAbbreviatorPatternsAppendLongPrefix() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatternsAppendLongPrefix(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final String PREFIX = "some random text big enough to be larger than abbreviated string ";
         final StringBuilder destination = new StringBuilder(PREFIX);
         abbreviator.abbreviate(this.getClass().getName(), destination);
@@ -75,9 +65,10 @@ public class NameAbbreviatorTest {
         assertEquals(PREFIX + expected, actual);
     }
 
-    @Test
-    public void testAbbreviatorPatternsAppend() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatternsAppend(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final String PREFIX = "some random text";
         final StringBuilder destination = new StringBuilder(PREFIX);
         abbreviator.abbreviate(this.getClass().getName(), destination);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
@@ -16,25 +16,25 @@
  */
 package org.apache.logging.log4j.core.selector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public final class BasicContextSelectorTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, BasicContextSelector.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/SourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/SourceTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.MalformedURLException;


### PR DESCRIPTION
### Introduction

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed `Milestone 1. Upgrade from JUnit 4 to JUnit 5`. This PR migrates the tests located in `x` to JUnit5.c

Please note the `log4j-core-test` module contains over 150 files and this PR updates the tests for 40 of them. Further PRs will be made to update the rest of the tests.

## Checklist

- [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
- [x] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
- [ ] Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
- [ ] Tests for the changes are provided
- [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
