### PR TITLE
Migrate log4j-jdbc-dbcp2 to JUnit 5

### DIFF
--- a/log4j-jdbc-dbcp2/pom.xml
+++ b/log4j-jdbc-dbcp2/pom.xml
@@ -69,12 +69,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/log4j-jdbc-dbcp2/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolableConnectionFactoryTest.java
+++ b/log4j-jdbc-dbcp2/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolableConnectionFactoryTest.java
@@ -16,22 +16,20 @@
  */
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
+
+@LoggerContextSource(value = "log4j2-jdbc-dbcp2.xml", timeout = 10)
 public class PoolableConnectionFactoryTest {
 
     private static final String REL_PATH = "src/test/resources/log4j2-jdbc-dbcp2.xml";
 
-    @ClassRule
-    public static final LoggerContextRule LCR = LoggerContextRule.createShutdownTimeoutLoggerContextRule(REL_PATH);
-
     @Test
-    public void test() {
-        final Appender appender = LCR.getAppender("databaseAppender");
-        Assert.assertNotNull("Problem loading configuration from " + REL_PATH, appender);
+    public void test(@Named("databaseAppender") final Appender appender) {
+        assertNotNull(appender, "Problem loading configuration from " + REL_PATH);
     }
 }

--- a/log4j-jdbc-dbcp2/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolingDriverConnectionSourceTest.java
+++ b/log4j-jdbc-dbcp2/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolingDriverConnectionSourceTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.test.appender.db.jdbc.JdbcH2TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PoolingDriverConnectionSourceTest {
 
@@ -75,9 +77,9 @@ public class PoolingDriverConnectionSourceTest {
     }
 
     private void openAndClose(final PoolingDriverConnectionSource source) throws SQLException {
-        Assert.assertNotNull("PoolingDriverConnectionSource is null", source);
+        assertNotNull(source, "PoolingDriverConnectionSource is null");
         try (final Connection conn = source.getConnection()) {
-            Assert.assertFalse(conn.isClosed());
+            assertFalse(conn.isClosed());
         } finally {
             source.stop();
         }


### PR DESCRIPTION
Hello! 👋

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed `Milestone 1. Upgrade from JUnit 4 to JUnit 5`. This PR migrates the tests located in `log4j-jdbc-dbcp2` to JUnit5.

- Our idea is to deliver small size PRs with the changes. If you'd like us to do it in some other way, please tell us so
- Part of the deliverable is to transport these changes from the `2.x` branch to the `main` branch. Should we create the PR against `main` once this PR is merged?

Thank you!