### PR TITLE
refactor: Migrate `log4j-jpl` to JUnit5

### DIFF
--- a/log4j-jpl/pom.xml
+++ b/log4j-jpl/pom.xml
@@ -58,11 +58,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/log4j-jpl/src/test/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerTest.java
+++ b/log4j-jpl/src/test/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.jpl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.lang.System.Logger;
 import java.util.List;
@@ -30,9 +30,9 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Log4jSystemLoggerTest {
 
@@ -41,7 +41,7 @@ public class Log4jSystemLoggerTest {
     protected ListAppender eventAppender;
     protected ListAppender stringAppender;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         logger = System.getLogger(LOGGER_NAME);
         assertThat(logger, instanceOf(Log4jSystemLogger.class));
@@ -51,7 +51,7 @@ public class Log4jSystemLoggerTest {
         assertNotNull(stringAppender);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (eventAppender != null) {
             eventAppender.clear();


### PR DESCRIPTION
### Introduction

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed `Milestone 1. Upgrade from JUnit 4 to JUnit 5`. This PR migrates the tests located in `log4j-jpl` to JUnit5.

## Checklist

- [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
- [x] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
- [ ] Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
- [ ] Tests for the changes are provided
- [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
