### PR TITLE
Migrate `Log4j slf4j2 impl` to junit5

### DIFF
--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -79,11 +79,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-to-slf4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -116,13 +111,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
+          <!-- Separate test execution to verify that the presence of both:
+            ~  * `log4j-slf4j2-impl` (bridge from SLF4J to Log4j API)
+            ~  * `log4j-to-slf4j` (bridge from Log4j API to SLF4J)
+            ~  does not cause a stack overflow.
+            -->
           <execution>
             <id>loop-test</id>
             <goals>
               <goal>test</goal>
             </goals>
-            <phase>test</phase>
             <configuration>
+              <additionalClasspathDependencies>
+                <dependency>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-to-slf4j</artifactId>
+                  <version>${project.version}</version>
+                </dependency>
+              </additionalClasspathDependencies>
               <includes>
                 <include>**/OverflowTest.java</include>
               </includes>
@@ -130,10 +136,6 @@
           </execution>
           <execution>
             <id>default-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <phase>test</phase>
             <configuration>
               <includes>
                 <include>**/*Test.java</include>
@@ -141,9 +143,6 @@
               <excludes>
                 <exclude>**/OverflowTest.java</exclude>
               </excludes>
-              <classpathDependencyExcludes>
-                <classpathDependencyExcludes>org.apache.logging.log4j:log4j-to-slf4j</classpathDependencyExcludes>
-              </classpathDependencyExcludes>
             </configuration>
           </execution>
         </executions>

--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -108,11 +108,6 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -131,7 +126,6 @@
               <includes>
                 <include>**/OverflowTest.java</include>
               </includes>
-              <includeJUnit5Engines>junit-vintage</includeJUnit5Engines>
             </configuration>
           </execution>
           <execution>

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/other/pkg/LoggerContextAnchorTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/other/pkg/LoggerContextAnchorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.other.pkg;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
@@ -16,29 +16,24 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.CallerBoundaryAware;
 import org.slf4j.spi.LoggingEventBuilder;
 
+@LoggerContextSource("log4j2-calling-class.xml")
 public class CallerInformationTest {
 
-    // config from log4j-core test-jar
-    private static final String CONFIG = "log4j2-calling-class.xml";
-
-    @ClassRule
-    public static final LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testClassLogger() throws Exception {
-        final ListAppender app = ctx.getListAppender("Class").clear();
+    public void testClassLogger(@Named("Class") final ListAppender app) throws Exception {
+        app.clear();
         final Logger logger = LoggerFactory.getLogger("ClassLogger");
         logger.info("Ignored message contents.");
         logger.warn("Verifying the caller class is still correct.");
@@ -47,15 +42,15 @@ public class CallerInformationTest {
         logger.atWarn().log("Verifying the caller class is still correct.");
         logger.atError().log("Hopefully nobody breaks me!");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 6, messages.size());
+        assertEquals(6, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller class name.", this.getClass().getName(), message);
+            assertEquals(this.getClass().getName(), message, "Incorrect caller class name.");
         }
     }
 
     @Test
-    public void testMethodLogger() throws Exception {
-        final ListAppender app = ctx.getListAppender("Method").clear();
+    public void testMethodLogger(@Named("Method") final ListAppender app) throws Exception {
+        app.clear();
         final Logger logger = LoggerFactory.getLogger("MethodLogger");
         logger.info("More messages.");
         logger.warn("CATASTROPHE INCOMING!");
@@ -68,23 +63,23 @@ public class CallerInformationTest {
         logger.atWarn().log("brains~~~");
         logger.atInfo().log("Itchy. Tasty.");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 10, messages.size());
+        assertEquals(10, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+            assertEquals("testMethodLogger", message, "Incorrect caller method name.");
         }
     }
 
     @Test
-    public void testFqcnLogger() throws Exception {
-        final ListAppender app = ctx.getListAppender("Fqcn").clear();
+    public void testFqcnLogger(@Named("Fqcn") final ListAppender app) throws Exception {
+        app.clear();
         final Logger logger = LoggerFactory.getLogger("FqcnLogger");
         LoggingEventBuilder loggingEventBuilder = logger.atInfo();
         ((CallerBoundaryAware) loggingEventBuilder).setCallerBoundary("MyFqcn");
         loggingEventBuilder.log("A message");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 1, messages.size());
+        assertEquals(1, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect fqcn.", "MyFqcn", message);
+            assertEquals("MyFqcn", message, "Incorrect fqcn.");
         }
     }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue("Logger is of type " + Holder.LOGGER.getClass().getName(), Holder.LOGGER instanceof Log4jLogger);
+            assertTrue(
+                    Holder.LOGGER instanceof Log4jLogger,
+                    "Logger is of type " + Holder.LOGGER.getClass().getName());
         }
     }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -47,8 +47,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue(
-                    Holder.LOGGER instanceof Log4jLogger,
+            assertInstanceOf(
+                    Log4jLogger.class,
+                    Holder.LOGGER,
                     "Logger is of type " + Holder.LOGGER.getClass().getName());
         }
     }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4jMarkerTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/Log4jMarkerTest.java
@@ -16,17 +16,19 @@
  */
 package org.apache.logging.slf4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class Log4jMarkerTest {
 
     private static Log4jMarkerFactory markerFactory;
 
-    @BeforeClass
+    @BeforeAll
     public static void startup() {
         markerFactory = ((Log4jLoggerFactory) org.slf4j.LoggerFactory.getILoggerFactory()).getMarkerFactory();
     }
@@ -38,9 +40,9 @@ public class Log4jMarkerTest {
         final Log4jMarker marker1 = new Log4jMarker(markerFactory, markerA);
         final Log4jMarker marker2 = new Log4jMarker(markerFactory, markerA);
         final Log4jMarker marker3 = new Log4jMarker(markerFactory, markerB);
-        Assert.assertEquals(marker1, marker2);
-        Assert.assertNotEquals(marker1, null);
-        Assert.assertNotEquals(null, marker1);
-        Assert.assertNotEquals(marker1, marker3);
+        assertEquals(marker1, marker2);
+        assertNotEquals(marker1, null);
+        assertNotEquals(null, marker1);
+        assertNotEquals(marker1, marker3);
     }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.spi.LoggerContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -35,9 +35,9 @@ public class LoggerContextTest {
         factory.getLogger("test");
         Set<LoggerContext> set = factory.getLoggerContexts();
         final LoggerContext ctx1 = set.toArray(LoggerContext.EMPTY_ARRAY)[0];
-        assertTrue("LoggerContext is not enabled for shutdown", ctx1 instanceof LifeCycle);
+        assertTrue(ctx1 instanceof LifeCycle, "LoggerContext is not enabled for shutdown");
         ((LifeCycle) ctx1).stop();
         set = factory.getLoggerContexts();
-        assertTrue("Expected no LoggerContexts", set.isEmpty());
+        assertTrue(set.isEmpty(), "Expected no LoggerContexts");
     }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -35,7 +36,7 @@ public class LoggerContextTest {
         factory.getLogger("test");
         Set<LoggerContext> set = factory.getLoggerContexts();
         final LoggerContext ctx1 = set.toArray(LoggerContext.EMPTY_ARRAY)[0];
-        assertTrue(ctx1 instanceof LifeCycle, "LoggerContext is not enabled for shutdown");
+        assertInstanceOf(LifeCycle.class, ctx1, "LoggerContext is not enabled for shutdown");
         ((LifeCycle) ctx1).stop();
         set = factory.getLoggerContexts();
         assertTrue(set.isEmpty(), "Expected no LoggerContexts");

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -38,13 +38,13 @@ public class MarkerTest {
     private static final String PARENT_MARKER_NAME = MarkerTest.class.getSimpleName() + "-PARENT";
     private static Log4jMarkerFactory markerFactory;
 
-    @BeforeClass
+    @BeforeAll
     public static void startup() {
         markerFactory = ((Log4jLoggerFactory) org.slf4j.LoggerFactory.getILoggerFactory()).getMarkerFactory();
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void clearMarkers() {
         MarkerManager.clear();
     }
@@ -59,17 +59,17 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMarkerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMakerName);
 
-        assertTrue("Incorrect Marker class", slf4jMarker instanceof Log4jMarker);
+        assertTrue(slf4jMarker instanceof Log4jMarker, "Incorrect Marker class");
         assertTrue(
+                log4jMarker.isInstanceOf(log4jParent),
                 String.format(
                         "%s (log4jMarker=%s) is not an instance of %s (log4jParent=%s) in Log4j",
-                        childMakerName, parentMarkerName, log4jMarker, log4jParent),
-                log4jMarker.isInstanceOf(log4jParent));
+                        childMakerName, parentMarkerName, log4jMarker, log4jParent));
         assertTrue(
+                slf4jMarker.contains(slf4jParent),
                 String.format(
                         "%s (slf4jMarker=%s) is not an instance of %s (log4jParent=%s) in SLF4J",
-                        childMakerName, parentMarkerName, slf4jMarker, slf4jParent),
-                slf4jMarker.contains(slf4jParent));
+                        childMakerName, parentMarkerName, slf4jMarker, slf4jParent));
     }
 
     @Test
@@ -109,15 +109,15 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMakerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMarkerName);
         assertTrue(
+                log4jMarker.isInstanceOf(log4jParent),
                 String.format(
                         "%s (log4jMarker=%s) is not an instance of %s (log4jParent=%s) in Log4j",
-                        childMarkerName, parentMakerName, log4jMarker, log4jParent),
-                log4jMarker.isInstanceOf(log4jParent));
+                        childMarkerName, parentMakerName, log4jMarker, log4jParent));
         assertTrue(
+                slf4jMarker.contains(slf4jParent),
                 String.format(
                         "%s (slf4jMarker=%s) is not an instance of %s (log4jParent=%s) in SLF4J",
-                        childMarkerName, parentMakerName, slf4jMarker, slf4jParent),
-                slf4jMarker.contains(slf4jParent));
+                        childMarkerName, parentMakerName, slf4jMarker, slf4jParent));
     }
 
     @Test
@@ -150,13 +150,13 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final org.slf4j.Marker nullMarker = null;
         try {
-            Assert.assertFalse(log4jSlf4jParent.contains(nullMarker));
+            assertFalse(log4jSlf4jParent.contains(nullMarker));
             fail("Expected " + IllegalArgumentException.class.getName());
         } catch (final IllegalArgumentException e) {
             // expected
         }
         try {
-            Assert.assertFalse(log4jSlf4jMarker.contains(nullMarker));
+            assertFalse(log4jSlf4jMarker.contains(nullMarker));
             fail("Expected " + IllegalArgumentException.class.getName());
         } catch (final IllegalArgumentException e) {
             // expected
@@ -175,8 +175,8 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jParent = new Log4jMarker(markerFactory, log4jParent);
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final String nullStr = null;
-        Assert.assertFalse(log4jSlf4jParent.contains(nullStr));
-        Assert.assertFalse(log4jSlf4jMarker.contains(nullStr));
+        assertFalse(log4jSlf4jParent.contains(nullStr));
+        assertFalse(log4jSlf4jMarker.contains(nullStr));
     }
 
     @Test
@@ -191,7 +191,7 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jParent = new Log4jMarker(markerFactory, log4jParent);
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final org.slf4j.Marker nullMarker = null;
-        Assert.assertFalse(log4jSlf4jParent.remove(nullMarker));
-        Assert.assertFalse(log4jSlf4jMarker.remove(nullMarker));
+        assertFalse(log4jSlf4jParent.remove(nullMarker));
+        assertFalse(log4jSlf4jMarker.remove(nullMarker));
     }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.slf4j;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -59,7 +60,7 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMarkerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMakerName);
 
-        assertTrue(slf4jMarker instanceof Log4jMarker, "Incorrect Marker class");
+        assertInstanceOf(Log4jMarker.class, slf4jMarker, "Incorrect Marker class");
         assertTrue(
                 log4jMarker.isInstanceOf(log4jParent),
                 String.format(

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/OverflowTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/OverflowTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.logging.log4j.LoggingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/SerializeTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/SerializeTest.java
@@ -20,21 +20,16 @@ import static org.apache.logging.log4j.test.SerializableMatchers.serializesRound
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-test1.xml")
 public class SerializeTest {
-
-    private static final String CONFIG = "log4j-test1.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
 
     Logger logger = LoggerFactory.getLogger("LoggerTest");
 


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in log4j-jakarta-smtp to JUnit5.

⚠️ We've found out that [`OverflowTest`](https://github.com/apache/logging-log4j2/blob/cbe7e91304cd0d3681a3c6eedc1782b25cb96242/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/OverflowTest.java) is [set to run specifically with Junit 4](https://github.com/apache/logging-log4j2/blob/cbe7e91304cd0d3681a3c6eedc1782b25cb96242/log4j-slf4j2-impl/pom.xml#L134). This behaviour was added not long ago so we wanted to ask, should we leave it like this or should we refactor `OverflowTest` to JUnit 5?

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
