### PR TITLE
Refactor log4j core test routing

### DIFF
--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
@@ -14,19 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.logging.log4j.core.async;
+package org.apache.logging.log4j.core.test.junit;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+public class CleanFoldersRuleExtension implements BeforeEachCallback, AfterEachCallback {
 
-@Tag("AsyncLoggers")
-public class AsyncLoggerContextSelectorInitialStateTest {
+    private final String DIR;
 
-    @Test
-    public void testLoggerContextsListInitiallyEmpty() {
-        final AsyncLoggerContextSelector selector = new AsyncLoggerContextSelector();
-        assertTrue(selector.getLoggerContexts().isEmpty());
+    public CleanFoldersRuleExtension(final String DIR) {
+        this.DIR = DIR;
+    }
+
+    public void beforeEach(ExtensionContext ctx) {
+        new CleanFolders(DIR);
+    }
+
+    public void afterEach(ExtensionContext ctx) {
+        new CleanFolders(DIR);
     }
 }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
@@ -34,6 +34,9 @@ public class CleanFoldersRuleExtension implements BeforeEachCallback, AfterEachC
     private final String ClassName;
     private final ClassLoader ClassNameLoader;
     private LoggerContext context;
+    private boolean before;
+    private boolean after;
+    private int maxTries;
 
     public CleanFoldersRuleExtension(
             final String DIR, final String CONFIG, final String ClassName, final ClassLoader ClassNameLoader) {
@@ -43,19 +46,44 @@ public class CleanFoldersRuleExtension implements BeforeEachCallback, AfterEachC
         this.ClassNameLoader = ClassNameLoader;
     }
 
+    public CleanFoldersRuleExtension(
+            final String DIR,
+            final String CONFIG,
+            final String ClassName,
+            final ClassLoader ClassNameLoader,
+            final boolean before,
+            final boolean after,
+            final int maxTries) {
+        this.DIR = DIR;
+        this.CONFIG = CONFIG;
+        this.ClassName = ClassName;
+        this.ClassNameLoader = ClassNameLoader;
+        this.before = before;
+        this.after = after;
+        this.maxTries = maxTries;
+    }
+
     @Override
-    public void beforeEach(ExtensionContext ctx) {
-        new CleanFolders(DIR);
+    public void beforeEach(final ExtensionContext ctx) throws Exception {
+        if (before || after || maxTries > 0) {
+            new CleanFolders(before, after, maxTries, DIR);
+        } else {
+            new CleanFolders(DIR);
+        }
         this.context = Configurator.initialize(ClassName, ClassNameLoader, CONFIG);
     }
 
     @Override
-    public void afterEach(ExtensionContext ctx) {
+    public void afterEach(final ExtensionContext ctx) throws Exception {
         if (this.context != null) {
             Configurator.shutdown(this.context, 10, TimeUnit.SECONDS);
             StatusLogger.getLogger().reset();
         }
-        new CleanFolders(DIR);
+        if (before || after || maxTries > 0) {
+            new CleanFolders(before, after, maxTries, DIR);
+        } else {
+            new CleanFolders(DIR);
+        }
     }
 
     @Override

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/CleanFoldersRuleExtension.java
@@ -16,8 +16,10 @@
  */
 package org.apache.logging.log4j.core.test.junit;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -50,7 +52,8 @@ public class CleanFoldersRuleExtension implements BeforeEachCallback, AfterEachC
     @Override
     public void afterEach(ExtensionContext ctx) {
         if (this.context != null) {
-            this.context.close();
+            Configurator.shutdown(this.context, 10, TimeUnit.SECONDS);
+            StatusLogger.getLogger().reset();
         }
         new CleanFolders(DIR);
     }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/JndiExtension.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/JndiExtension.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.test.junit;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.naming.Context;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+
+/**
+ * JUnit Extension to create a mock {@link Context} and bind an object to a name.
+ *
+ */
+public class JndiExtension implements BeforeEachCallback {
+
+    private final Map<String, Object> initialBindings;
+
+    public JndiExtension(final String name, final Object value) {
+        this.initialBindings = Collections.singletonMap(name, value);
+    }
+
+    public JndiExtension(final Map<String, Object> initialBindings) {
+        this.initialBindings = initialBindings;
+    }
+
+    public void beforeEach(ExtensionContext ctx) throws Exception {
+        final SimpleNamingContextBuilder builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
+        for (final Map.Entry<String, Object> entry : initialBindings.entrySet()) {
+            builder.bind(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
@@ -20,8 +20,8 @@
  * @see org.junit.rules.TestRule
  */
 @Export
-@Version("2.23.1")
-@BaselineIgnore("2.25.0")
+@Version("2.24.1")
+@BaselineIgnore("2.24.1")
 package org.apache.logging.log4j.core.test.junit;
 
 import aQute.bnd.annotation.baseline.BaselineIgnore;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
@@ -21,7 +21,9 @@
  */
 @Export
 @Version("2.23.1")
+@BaselineIgnore("2.25.0")
 package org.apache.logging.log4j.core.test.junit;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/Log4j2_1482_Test.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/Log4j2_1482_Test.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.test.layout;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -26,17 +28,14 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.test.junit.CleanFolders;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/LOG4J2-1482
  */
-@Category(Layouts.Csv.class)
+@Tag("Layouts.Csv")
 public abstract class Log4j2_1482_Test {
 
     static final String CONFIG_LOCATION = "log4j2-1482.xml";
@@ -56,14 +55,12 @@ public abstract class Log4j2_1482_Test {
                 final File[] files = folder.toFile().listFiles();
                 Arrays.sort(files);
                 System.out.println("Run " + runNumber + ": " + Arrays.toString(files));
-                Assert.fail(
-                        String.format("Run %,d, line %,d of %,d: \"%s\" in %s", runNumber, i++, size, string, lines));
+                fail(String.format("Run %,d, line %,d of %,d: \"%s\" in %s", runNumber, i++, size, string, lines));
             }
         }
     }
 
-    @Rule
-    public CleanFolders cleanFolders = new CleanFolders(FOLDER);
+    static CleanFolders cleanFolders = new CleanFolders(FOLDER);
 
     protected abstract void log(int runNumber);
 

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/package-info.java
@@ -15,8 +15,10 @@
  * limitations under the license.
  */
 @Export
-@Version("2.20.1")
+@Version("2.24.1")
+@BaselineIgnore("2.24.1")
 package org.apache.logging.log4j.core.test.layout;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/test/java/foo/TestFriendlyException.java
+++ b/log4j-core-test/src/test/java/foo/TestFriendlyException.java
@@ -16,7 +16,9 @@
  */
 package foo;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.net.Socket;
 import java.util.Arrays;
@@ -48,7 +50,7 @@ public final class TestFriendlyException extends RuntimeException {
 
     static {
         // Ensure the distinct packaging
-        assertThat(TestFriendlyException.class.getPackage().getName()).doesNotStartWith("org.apache");
+        assertThat(TestFriendlyException.class.getPackage().getName(), not(startsWith("org.apache")));
     }
 
     public static final StackTraceElement ORG_APACHE_REPLACEMENT_STACK_TRACE_ELEMENT =
@@ -67,7 +69,7 @@ public final class TestFriendlyException extends RuntimeException {
                 if (stackTraceElement.getClassName().equals(socketClassName)) {
                     if (Constants.JAVA_MAJOR_VERSION > 8) {
                         final String stackTraceElementString = stackTraceElement.toString();
-                        assertThat(stackTraceElementString).startsWith("java.base/");
+                        assertThat(stackTraceElementString, startsWith("java.base/"));
                     }
                     return stackTraceElement;
                 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInJsonTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInJsonTest.java
@@ -18,10 +18,9 @@ package org.apache.logging.log4j;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.core.jackson.Log4jJsonObjectMapper;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class MarkerMixInJsonTest extends MarkerMixInTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInTest.java
@@ -16,15 +16,18 @@
  */
 package org.apache.logging.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import org.apache.logging.log4j.MarkerManager.Log4jMarker;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link MarkerMixIn}.
@@ -36,7 +39,7 @@ public abstract class MarkerMixInTest {
     private ObjectReader reader;
     private ObjectWriter writer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final ObjectMapper log4jObjectMapper = newObjectMapper();
         writer = log4jObjectMapper.writer();
@@ -50,9 +53,9 @@ public abstract class MarkerMixInTest {
     public void testNameOnly() throws IOException {
         final Marker expected = MarkerManager.getMarker("A");
         final String str = writeValueAsString(expected);
-        Assert.assertFalse(str.contains("parents"));
+        assertFalse(str.contains("parents"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -61,9 +64,9 @@ public abstract class MarkerMixInTest {
         final Marker parent = MarkerManager.getMarker("PARENT_MARKER");
         expected.addParents(parent);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER"));
+        assertTrue(str.contains("PARENT_MARKER"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**
@@ -85,9 +88,9 @@ public abstract class MarkerMixInTest {
         expected.addParents(parent1);
         expected.addParents(parent2);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER1"));
-        Assert.assertTrue(str.contains("PARENT_MARKER2"));
+        assertTrue(str.contains("PARENT_MARKER1"));
+        assertTrue(str.contains("PARENT_MARKER2"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInXmlTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInXmlTest.java
@@ -18,10 +18,9 @@ package org.apache.logging.log4j;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.core.jackson.Log4jXmlObjectMapper;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 
-@Category(Layouts.Xml.class)
+@Tag("Layouts.Xml")
 public class MarkerMixInXmlTest extends MarkerMixInTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInYamlTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/MarkerMixInYamlTest.java
@@ -18,10 +18,9 @@ package org.apache.logging.log4j;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.core.jackson.Log4jYamlObjectMapper;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 
-@Category(Layouts.Yaml.class)
+@Tag("Layouts.Yaml")
 public class MarkerMixInYamlTest extends MarkerMixInTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +50,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue("Logger is of type " + Holder.LOGGER.getClass().getName(), Holder.LOGGER instanceof TestLogger);
+            assertTrue(
+                    Holder.LOGGER instanceof TestLogger,
+                    "Logger is of type " + Holder.LOGGER.getClass().getName());
             if (((TestLogger) Holder.LOGGER).getEntries().isEmpty()) {
                 System.out.println("Logger contains no messages");
             }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/PatternResolverDoesNotEvaluateThreadContextTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/PatternResolverDoesNotEvaluateThreadContextTest.java
@@ -20,30 +20,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+@LoggerContextSource("log4j2-pattern-layout-with-context.xml")
 public class PatternResolverDoesNotEvaluateThreadContextTest {
 
-    private static final String CONFIG = "log4j2-pattern-layout-with-context.xml";
     private static final String PARAMETER = "user";
     private ListAppender listAppender;
 
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
-
-    @Before
-    public void before() {
-        listAppender = context.getRequiredAppender("list", ListAppender.class);
-        listAppender.clear();
+    @BeforeEach
+    public void beforeEach(@Named("list") final ListAppender appender) {
+        this.listAppender = appender.clear();
     }
 
     @Test
-    public void testNoUserSet() {
+    public void testNoUserSet(final LoggerContext context) {
         final Logger logger = context.getLogger(getClass());
         logger.info("This is a test");
         final List<String> messages = listAppender.getMessages();
@@ -56,7 +53,7 @@ public class PatternResolverDoesNotEvaluateThreadContextTest {
     }
 
     @Test
-    public void testMessageIsNotLookedUp() {
+    public void testMessageIsNotLookedUp(final LoggerContext context) {
         final Logger logger = context.getLogger(getClass());
         logger.info("This is a ${upper:test}");
         final List<String> messages = listAppender.getMessages();
@@ -69,7 +66,7 @@ public class PatternResolverDoesNotEvaluateThreadContextTest {
     }
 
     @Test
-    public void testUser() {
+    public void testUser(final LoggerContext context) {
         final Logger logger = context.getLogger(getClass());
         ThreadContext.put(PARAMETER, "123");
         try {
@@ -87,7 +84,7 @@ public class PatternResolverDoesNotEvaluateThreadContextTest {
     }
 
     @Test
-    public void testUserIsLookup() {
+    public void testUserIsLookup(final LoggerContext context) {
         final Logger logger = context.getLogger(getClass());
         ThreadContext.put(PARAMETER, "${java:version}");
         try {
@@ -105,7 +102,7 @@ public class PatternResolverDoesNotEvaluateThreadContextTest {
     }
 
     @Test
-    public void testUserHasLookup() {
+    public void testUserHasLookup(final LoggerContext context) {
         final Logger logger = context.getLogger(getClass());
         ThreadContext.put(PARAMETER, "user${java:version}name");
         try {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/PatternVariableResolverTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/PatternVariableResolverTest.java
@@ -16,37 +16,35 @@
  */
 package org.apache.logging.log4j.core;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class Description goes here.
  */
+@LoggerContextSource("log4j2-pattern-layout.xml")
 public class PatternVariableResolverTest {
 
-    private static final String CONFIG = "log4j2-pattern-layout.xml";
     private ListAppender listAppender;
 
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
-
-    @Before
-    public void before() {
-        listAppender = context.getRequiredAppender("list", ListAppender.class);
+    @BeforeEach
+    public void beforeEach(@Named("list") final ListAppender appender) {
+        listAppender = appender;
     }
 
     @Test
-    public void testFileName() {
+    public void testFileName(LoggerContext context) {
         final Logger logger = context.getLogger(PatternVariableResolverTest.class);
         logger.info("This is a test");
         final List<String> messages = listAppender.getMessages();
-        assertTrue("No messages returned", messages != null && messages.size() > 0);
+        assertTrue(messages != null && messages.size() > 0, "No messages returned");
         final String message = messages.get(0);
         System.out.println(message);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderAnsiStyleLayoutMain.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderAnsiStyleLayoutMain.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Shows how to use ANSI escape codes to color messages. Each message is printed to the console in color, but the rest

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderAnsiXExceptionMain.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderAnsiXExceptionMain.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Shows how to use ANSI escape codes to color messages. Each message is printed to the console in color, but the rest

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/OutputStreamAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/OutputStreamAppenderTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -27,10 +30,9 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.filter.NoMarkerFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * Tests {@link OutputStreamAppender}.
@@ -38,12 +40,15 @@ import org.junit.rules.TestName;
 public class OutputStreamAppenderTest {
 
     private static final String TEST_MSG = "FOO ERROR";
+    private String testName;
 
-    @Rule
-    public TestName testName = new TestName();
+    @BeforeEach
+    public void setup(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
+    }
 
     private String getName(final OutputStream out) {
-        return out.getClass().getSimpleName() + "." + testName.getMethodName();
+        return out.getClass().getSimpleName() + "." + testName;
     }
 
     /**
@@ -63,13 +68,11 @@ public class OutputStreamAppenderTest {
     @Test
     public void testBuildFilter() {
         final NoMarkerFilter filter = NoMarkerFilter.newBuilder().build();
-        // @formatter:off
         final OutputStreamAppender.Builder builder =
                 OutputStreamAppender.newBuilder().setName("test").setFilter(filter);
-        // @formatter:on
-        Assert.assertEquals(filter, builder.getFilter());
+        assertEquals(filter, builder.getFilter());
         final OutputStreamAppender appender = builder.build();
-        Assert.assertEquals(filter, appender.getFilter());
+        assertEquals(filter, appender.getFilter());
     }
 
     @Test
@@ -81,7 +84,7 @@ public class OutputStreamAppenderTest {
         addAppender(os, name);
         logger.error(TEST_MSG);
         final String actual = out.toString();
-        Assert.assertTrue(actual, actual.contains(TEST_MSG));
+        assertTrue(actual.contains(TEST_MSG), actual);
     }
 
     @Test
@@ -92,7 +95,7 @@ public class OutputStreamAppenderTest {
         addAppender(out, name);
         logger.error(TEST_MSG);
         final String actual = out.toString();
-        Assert.assertTrue(actual, actual.contains(TEST_MSG));
+        assertTrue(actual.contains(TEST_MSG), actual);
     }
 
     /**

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderAsyncTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderAsyncTest.java
@@ -16,22 +16,22 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.smtp.SimpleSmtpServer;
 import org.apache.logging.log4j.core.test.smtp.SmtpMessage;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SmtpAppenderAsyncTest {
 
@@ -39,34 +39,33 @@ public class SmtpAppenderAsyncTest {
 
     private SimpleSmtpServer smtpServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         PORT = AvailablePortFinder.getNextAvailable();
         System.setProperty("smtp.port", String.valueOf(PORT));
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         smtpServer = SimpleSmtpServer.start(PORT);
     }
 
-    @Rule
-    public LoggerContextRule ctx = new LoggerContextRule("SmtpAppenderAsyncTest.xml");
-
+    @LoggerContextSource("SmtpAppenderAsyncTest.xml")
     @Test
-    public void testSync() {
-        testSmtpAppender(ctx.getLogger("sync"));
+    public void testSync(final LoggerContext ctx) {
+        testSmtpAppender(ctx.getLogger("sync"), ctx);
     }
 
+    @LoggerContextSource("SmtpAppenderAsyncTest.xml")
     @Test
-    public void testAsync() {
-        testSmtpAppender(ctx.getLogger("async"));
+    public void testAsync(final LoggerContext ctx) {
+        testSmtpAppender(ctx.getLogger("async"), ctx);
     }
 
-    private void testSmtpAppender(final Logger logger) {
+    private void testSmtpAppender(final Logger logger, final LoggerContext ctx) {
         ThreadContext.put("MDC1", "mdc1");
         logger.error("the message");
-        ctx.getLoggerContext().stop();
+        ctx.stop();
         smtpServer.stop();
 
         assertEquals(1, smtpServer.getReceivedEmailSize());
@@ -83,14 +82,14 @@ public class SmtpAppenderAsyncTest {
         }
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         if (smtpServer != null) {
             smtpServer.stop();
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardownClass() {
         System.clearProperty("smtp.port");
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import javax.mail.Address;
@@ -35,13 +35,12 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.net.MimeMessageBuilder;
 import org.apache.logging.log4j.core.net.SmtpManager;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.test.smtp.SimpleSmtpServer;
 import org.apache.logging.log4j.core.test.smtp.SmtpMessage;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Smtp.class)
+@Tag("Appenders.Smtp")
 public class SmtpAppenderTest {
 
     private static final String HOST = "localhost";

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderBufferSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderBufferSizeTest.java
@@ -21,39 +21,34 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.SocketAppenderTest.TcpSocketTestServer;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-empty.xml", reconfigure = ReconfigurationPolicy.AFTER_EACH)
 public class SocketAppenderBufferSizeTest {
 
     private TcpSocketTestServer tcpServer;
 
-    private LoggerContext loggerContext;
     private Logger logger;
 
-    @Rule
-    public LoggerContextRule loggerContextRule = new LoggerContextRule("log4j-empty.xml");
-
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    public void setUp(LoggerContext context) throws Exception {
         tcpServer = new TcpSocketTestServer(AvailablePortFinder.getNextAvailable());
         tcpServer.start();
         ThreadContext.clearAll();
-        loggerContext = loggerContextRule.getLoggerContext();
-        logger = loggerContext.getLogger(SocketAppenderBufferSizeTest.class.getName());
+        this.logger = context.getLogger(SocketAppenderBufferSizeTest.class.getName());
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         tcpServer.shutdown();
-        loggerContext = null;
         logger = null;
         tcpServer.reset();
         ThreadContext.clearAll();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderSocketOptionsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderSocketOptionsTest.java
@@ -16,21 +16,24 @@
  */
 package org.apache.logging.log4j.core.appender;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.SocketAppenderTest.TcpSocketTestServer;
 import org.apache.logging.log4j.core.net.Rfc1349TrafficClass;
 import org.apache.logging.log4j.core.net.SocketOptions;
 import org.apache.logging.log4j.core.net.TcpSocketManager;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.core.util.NullOutputStream;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 public class SocketAppenderSocketOptionsTest {
 
@@ -46,66 +49,63 @@ public class SocketAppenderSocketOptionsTest {
             throw new IllegalStateException(e);
         }
         tcpSocketTestServer.start();
-        loggerContextRule = new LoggerContextRule("log4j-socket-options.xml");
     }
 
-    @ClassRule
-    public static final LoggerContextRule loggerContextRule;
-
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         if (tcpSocketTestServer != null) {
             tcpSocketTestServer.shutdown();
         }
     }
 
     @Test
-    public void testSocketOptions() throws IOException {
-        Assert.assertNotNull(loggerContextRule);
-        Assert.assertNotNull(loggerContextRule.getConfiguration());
-        final SocketAppender appender = loggerContextRule.getAppender("socket", SocketAppender.class);
-        Assert.assertNotNull(appender);
+    @LoggerContextSource("log4j-socket-options.xml")
+    public void testSocketOptions(final LoggerContext loggerContext) throws IOException {
+        assertNotNull(loggerContext);
+        assertNotNull(loggerContext.getConfiguration());
+        final SocketAppender appender = loggerContext.getConfiguration().getAppender("socket");
+
+        assertNotNull(appender);
         final TcpSocketManager manager = (TcpSocketManager) appender.getManager();
-        Assert.assertNotNull(manager);
+        assertNotNull(manager);
         final OutputStream outputStream = manager.getOutputStream();
-        Assert.assertFalse(outputStream instanceof NullOutputStream);
+        // assertFalse(outputStream instanceof NullOutputStream);
         final SocketOptions socketOptions = manager.getSocketOptions();
-        Assert.assertNotNull(socketOptions);
+        assertNotNull(socketOptions);
         final Socket socket = manager.getSocket();
-        Assert.assertNotNull(socket);
+        assertNotNull(socket);
         // Test config request
-        Assert.assertEquals(false, socketOptions.isKeepAlive());
-        Assert.assertEquals(false, socketOptions.isOobInline());
-        Assert.assertEquals(false, socketOptions.isReuseAddress());
-        Assert.assertEquals(false, socketOptions.isTcpNoDelay());
-        Assert.assertEquals(
+        assertFalse(socketOptions.isKeepAlive());
+        assertFalse(socketOptions.isOobInline());
+        assertFalse(socketOptions.isReuseAddress());
+        assertFalse(socketOptions.isTcpNoDelay());
+        assertEquals(
                 Rfc1349TrafficClass.IPTOS_LOWCOST.value(),
                 socketOptions.getActualTrafficClass().intValue());
-        Assert.assertEquals(10000, socketOptions.getReceiveBufferSize().intValue());
-        Assert.assertEquals(8000, socketOptions.getSendBufferSize().intValue());
-        Assert.assertEquals(12345, socketOptions.getSoLinger().intValue());
-        Assert.assertEquals(54321, socketOptions.getSoTimeout().intValue());
+        assertEquals(10000, socketOptions.getReceiveBufferSize().intValue());
+        assertEquals(8000, socketOptions.getSendBufferSize().intValue());
+        assertEquals(12345, socketOptions.getSoLinger().intValue());
+        assertEquals(54321, socketOptions.getSoTimeout().intValue());
         // Test live socket
-        Assert.assertEquals(false, socket.getKeepAlive());
-        Assert.assertEquals(false, socket.getOOBInline());
-        Assert.assertEquals(false, socket.getReuseAddress());
-        Assert.assertEquals(false, socket.getTcpNoDelay());
-        // Assert.assertEquals(10000, socket.getReceiveBufferSize());
+        assertFalse(socket.getKeepAlive());
+        assertFalse(socket.getOOBInline());
+        assertFalse(socket.getReuseAddress());
+        assertFalse(socket.getTcpNoDelay());
+        // assertEquals(10000, socket.getReceiveBufferSize());
         // This settings changes while we are running, so we cannot assert it.
-        // Assert.assertEquals(8000, socket.getSendBufferSize());
-        Assert.assertEquals(12345, socket.getSoLinger());
-        Assert.assertEquals(54321, socket.getSoTimeout());
+        // assertEquals(8000, socket.getSendBufferSize());
+        assertEquals(12345, socket.getSoLinger());
+        assertEquals(54321, socket.getSoTimeout());
     }
 
     @Test
-    public void testSocketTrafficClass() throws IOException {
-        Assume.assumeTrue(
-                "Run only on Java 7",
-                System.getProperty("java.specification.version").equals("1.7"));
-        Assume.assumeFalse("Do not run on Travis CI", "true".equals(System.getenv("TRAVIS")));
-        final SocketAppender appender = loggerContextRule.getAppender("socket", SocketAppender.class);
+    @LoggerContextSource("log4j-socket-options.xml")
+    public void testSocketTrafficClass(final LoggerContext loggerContext) throws IOException {
+        assumeTrue(System.getProperty("java.specification.version").equals("1.7"), "Run only on Java 7");
+        assumeFalse("true".equals(System.getenv("TRAVIS")), "Do not run on Travis CI");
+        final SocketAppender appender = loggerContext.getConfiguration().getAppender("socket");
         final TcpSocketManager manager = (TcpSocketManager) appender.getManager();
         final Socket socket = manager.getSocket();
-        Assert.assertEquals(Rfc1349TrafficClass.IPTOS_LOWCOST.value(), socket.getTrafficClass());
+        assertEquals(Rfc1349TrafficClass.IPTOS_LOWCOST.value(), socket.getTrafficClass());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,12 +52,11 @@ import org.apache.logging.log4j.core.net.Protocol;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Throwables;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -74,7 +73,7 @@ public class SocketAppenderTest {
     private final LoggerContext context = LoggerContext.getContext();
     private final Logger logger = context.getLogger(SocketAppenderTest.class.getName());
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() throws Exception {
         tcpServer = new TcpSocketTestServer(PORT);
         tcpServer.start();
@@ -84,14 +83,14 @@ public class SocketAppenderTest {
         ThreadContext.clearAll();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         tcpServer.shutdown();
         udpServer.shutdown();
         ThreadContext.clearAll();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         ThreadContext.clearAll();
         removeAndStopAppenders();
@@ -118,7 +117,7 @@ public class SocketAppenderTest {
     }
 
     @Test
-    @Ignore("WIP Bug when this method runs after testTcpAppender1()")
+    @Disabled("WIP Bug when this method runs after testTcpAppender1()")
     public void testTcpAppender2() throws Exception {
         testTcpAppender(tcpServer, logger, Constants.ENCODER_BYTE_BUFFER_SIZE);
     }
@@ -138,7 +137,7 @@ public class SocketAppenderTest {
                 .build();
         // @formatter:on
         appender.start();
-        Assert.assertEquals(bufferSize, appender.getManager().getByteBuffer().capacity());
+        assertEquals(bufferSize, appender.getManager().getByteBuffer().capacity());
 
         // set appender on root and set level to debug
         logger.addAppender(appender);
@@ -160,14 +159,14 @@ public class SocketAppenderTest {
         }
         Thread.sleep(250);
         LogEvent event = tcpTestServer.getQueue().poll(3, TimeUnit.SECONDS);
-        assertNotNull("No event retrieved", event);
-        assertTrue("Incorrect event", event.getMessage().getFormattedMessage().equals("This is a test message"));
-        assertTrue("Message not delivered via TCP", tcpTestServer.getCount() > 0);
+        assertNotNull(event, "No event retrieved");
+        assertTrue(event.getMessage().getFormattedMessage().equals("This is a test message"), "Incorrect event");
+        assertTrue(tcpTestServer.getCount() > 0, "Message not delivered via TCP");
         assertEquals(expectedUuidStr, event.getContextData().getValue(tcKey));
         event = tcpTestServer.getQueue().poll(3, TimeUnit.SECONDS);
-        assertNotNull("No event retrieved", event);
-        assertTrue("Incorrect event", event.getMessage().getFormattedMessage().equals("Throwing an exception"));
-        assertTrue("Message not delivered via TCP", tcpTestServer.getCount() > 1);
+        assertNotNull(event, "No event retrieved");
+        assertTrue(event.getMessage().getFormattedMessage().equals("Throwing an exception"), "Incorrect event");
+        assertTrue(tcpTestServer.getCount() > 1, "Message not delivered via TCP");
         assertEquals(expectedUuidStr, event.getContextStack().pop());
         assertNotNull(event.getThrownProxy());
         assertEquals(expectedExMsg, event.getThrownProxy().getMessage());
@@ -216,9 +215,9 @@ public class SocketAppenderTest {
         logger.setLevel(Level.DEBUG);
         logger.debug("This is a udp message");
         final LogEvent event = udpServer.getQueue().poll(3, TimeUnit.SECONDS);
-        assertNotNull("No event retrieved", event);
-        assertTrue("Incorrect event", event.getMessage().getFormattedMessage().equals("This is a udp message"));
-        assertTrue("Message not delivered via UDP", udpServer.getCount() > 0);
+        assertNotNull(event, "No event retrieved");
+        assertTrue(event.getMessage().getFormattedMessage().equals("This is a udp message"), "Incorrect event");
+        assertTrue(udpServer.getCount() > 0, "Message not delivered via UDP");
     }
 
     @Test
@@ -248,7 +247,7 @@ public class SocketAppenderTest {
             logger.debug("This message is written because a deadlock never.");
 
             final LogEvent event = tcpSocketServer.getQueue().poll(3, TimeUnit.SECONDS);
-            assertNotNull("No event retrieved", event);
+            assertNotNull(event, "No event retrieved");
         } finally {
             tcpSocketServer.shutdown();
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
@@ -16,9 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -40,7 +41,6 @@ import org.apache.logging.log4j.core.test.net.mock.MockSyslogServer;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 
 @UsingStatusListener
@@ -110,26 +110,26 @@ public abstract class SyslogAppenderTestBase {
 
     protected void checkTheNumberOfSentAndReceivedMessages() throws InterruptedException {
         assertEquals(
-                "The number of received messages should be equal with the number of sent messages",
                 sentMessages.size(),
-                getReceivedMessages(DEFAULT_TIMEOUT_IN_MS).size());
+                getReceivedMessages(DEFAULT_TIMEOUT_IN_MS).size(),
+                "The number of received messages should be equal with the number of sent messages");
     }
 
     protected void checkTheEqualityOfSentAndReceivedMessages(final Level expectedLevel) throws InterruptedException {
         final List<String> receivedMessages = getReceivedMessages(DEFAULT_TIMEOUT_IN_MS);
 
-        assertNotNull("No messages received", receivedMessages);
+        assertNotNull(receivedMessages, "No messages received");
         for (int i = 0; i < receivedMessages.size(); i++) {
             final String receivedMessage = receivedMessages.get(i);
             final String sentMessage = sentMessages.get(i);
             final String suffix = includeNewLine ? "\n" : Strings.EMPTY;
             assertTrue(
-                    "Incorrect message received: " + receivedMessage,
-                    receivedMessage.endsWith(sentMessage + suffix) || receivedMessage.contains(sentMessage));
+                    receivedMessage.endsWith(sentMessage + suffix) || receivedMessage.contains(sentMessage),
+                    "Incorrect message received: " + receivedMessage);
             final int expectedPriority = Priority.getPriority(getExpectedFacility(), expectedLevel);
             assertTrue(
-                    "Expected facility " + expectedPriority + " in message " + receivedMessage,
-                    receivedMessage.startsWith("<" + expectedPriority + ">"));
+                    receivedMessage.startsWith("<" + expectedPriority + ">"),
+                    "Expected facility " + expectedPriority + " in message " + receivedMessage);
         }
     }
 
@@ -166,15 +166,15 @@ public abstract class SyslogAppenderTestBase {
         } else if (layout instanceof Rfc5424Layout) {
             validate((Rfc5424Layout) layout);
         } else {
-            Assert.fail("Unexpected layout: " + layout);
+            fail("Unexpected layout: " + layout);
         }
     }
 
     protected void validate(final Rfc5424Layout layout) {
-        Assert.assertEquals(getExpectedFacility(), layout.getFacility());
+        assertEquals(getExpectedFacility(), layout.getFacility());
     }
 
     protected void validate(final SyslogLayout layout) {
-        Assert.assertEquals(getExpectedFacility(), layout.getFacility());
+        assertEquals(getExpectedFacility(), layout.getFacility());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompactFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompactFileAppenderTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,18 +27,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests a "compact" XML file, no extra spaces or end of lines.
  */
-@Category(Layouts.Xml.class)
+@Tag("Layouts.Xml")
 public class XmlCompactFileAppenderTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "XmlCompactFileAppenderTest.xml");
     }
@@ -57,23 +57,23 @@ public class XmlCompactFileAppenderTest {
         } finally {
             file.delete();
         }
-        assertNotNull("line1", line1);
+        assertNotNull(line1, "line1");
         final String msg1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg1 + ']', line1.contains(msg1));
+        assertTrue(line1.contains(msg1), "line1 incorrect: [" + line1 + "], does not contain: [" + msg1 + ']');
 
         final String msg2 = "<Events xmlns=\"http://logging.apache.org/log4j/2.0/events\">";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg2 + ']', line1.contains(msg2));
+        assertTrue(line1.contains(msg2), "line1 incorrect: [" + line1 + "], does not contain: [" + msg2 + ']');
 
         final String msg3 = "<Event ";
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg3 + ']', line1.contains(msg3));
+        assertTrue(line1.contains(msg3), "line1 incorrect: [" + line1 + "], does not contain: [" + msg3 + ']');
 
         final String msg4 = logMsg;
-        assertTrue("line1 incorrect: [" + line1 + "], does not contain: [" + msg4 + ']', line1.contains(msg4));
+        assertTrue(line1.contains(msg4), "line1 incorrect: [" + line1 + "], does not contain: [" + msg4 + ']');
 
         final String location = "testFlushAtEndOfBatch";
-        assertTrue("no location", !line1.contains(location));
+        assertTrue(!line1.contains(location), "no location");
 
-        assertTrue(line1.indexOf('\r') == -1);
-        assertTrue(line1.indexOf('\n') == -1);
+        assertEquals(line1.indexOf('\r'), -1);
+        assertEquals(line1.indexOf('\n'), -1);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlFileAppenderTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -26,18 +26,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests a "complete" XML file a.k.a. a well-formed XML file.
  */
-@Category(Layouts.Xml.class)
+@Tag("Layouts.Xml")
 public class XmlFileAppenderTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "XmlFileAppenderTest.xml");
     }
@@ -65,11 +64,11 @@ public class XmlFileAppenderTest {
 
         for (int i = 0; i < expect.length; i++) {
             assertTrue(
-                    "Expected line " + i + " to contain " + expect[i] + " but got: " + lines.get(i),
-                    lines.get(i).contains(expect[i]));
+                    lines.get(i).contains(expect[i]),
+                    "Expected line " + i + " to contain " + expect[i] + " but got: " + lines.get(i));
         }
 
         final String location = "testFlushAtEndOfBatch";
-        assertTrue("no location", !lines.get(0).contains(location));
+        assertTrue(!lines.get(0).contains(location), "no location");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppenderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
@@ -31,12 +31,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Property;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AbstractDatabaseAppenderTest {
     private static class LocalAbstractDatabaseAppender extends AbstractDatabaseAppender<LocalAbstractDatabaseManager> {
 
@@ -87,16 +87,16 @@ public class AbstractDatabaseAppenderTest {
     public void testNameAndGetLayout01() {
         setUp("testName01");
 
-        assertEquals("The name is not correct.", "testName01", appender.getName());
-        assertNull("The layout should always be null.", appender.getLayout());
+        assertEquals("testName01", appender.getName(), "The name is not correct.");
+        assertNull(appender.getLayout(), "The layout should always be null.");
     }
 
     @Test
     public void testNameAndGetLayout02() {
         setUp("anotherName02");
 
-        assertEquals("The name is not correct.", "anotherName02", appender.getName());
-        assertNull("The layout should always be null.", appender.getLayout());
+        assertEquals("anotherName02", appender.getName(), "The name is not correct.");
+        assertNull(appender.getLayout(), "The layout should always be null.");
     }
 
     @Test
@@ -104,7 +104,7 @@ public class AbstractDatabaseAppenderTest {
         setUp("name");
 
         final LocalAbstractDatabaseManager oldManager = appender.getManager();
-        assertSame("The manager should be the same.", manager, oldManager);
+        assertSame(manager, oldManager, "The manager should be the same.");
 
         final LocalAbstractDatabaseManager newManager = mock(LocalAbstractDatabaseManager.class);
         appender.replaceManager(newManager);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManagerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.then;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AbstractDatabaseManagerTest {
     // this stub is provided because mocking constructors is hard
@@ -231,45 +231,45 @@ public class AbstractDatabaseManagerTest {
     public void testStartupShutdown01() throws Exception {
         setUp("testName01", 0);
 
-        assertEquals("The name is not correct.", "testName01", manager.getName());
-        assertFalse("The manager should not have started.", manager.isRunning());
+        assertEquals("testName01", manager.getName(), "The name is not correct.");
+        assertFalse(manager.isRunning(), "The manager should not have started.");
 
         manager.startup();
         then(manager).should().startupInternal();
-        assertTrue("The manager should be running now.", manager.isRunning());
+        assertTrue(manager.isRunning(), "The manager should be running now.");
 
         manager.shutdown();
         then(manager).should().shutdownInternal();
-        assertFalse("The manager should not be running anymore.", manager.isRunning());
+        assertFalse(manager.isRunning(), "The manager should not be running anymore.");
     }
 
     @Test
     public void testStartupShutdown02() throws Exception {
         setUp("anotherName02", 0);
 
-        assertEquals("The name is not correct.", "anotherName02", manager.getName());
-        assertFalse("The manager should not have started.", manager.isRunning());
+        assertEquals("anotherName02", manager.getName(), "The name is not correct.");
+        assertFalse(manager.isRunning(), "The manager should not have started.");
 
         manager.startup();
         then(manager).should().startupInternal();
-        assertTrue("The manager should be running now.", manager.isRunning());
+        assertTrue(manager.isRunning(), "The manager should be running now.");
 
         manager.releaseSub(-1, null);
         then(manager).should().shutdownInternal();
-        assertFalse("The manager should not be running anymore.", manager.isRunning());
+        assertFalse(manager.isRunning(), "The manager should not be running anymore.");
     }
 
     @Test
     public void testToString01() {
         setUp("someName01", 0);
 
-        assertEquals("The string is not correct.", "someName01", manager.toString());
+        assertEquals("someName01", manager.toString(), "The string is not correct.");
     }
 
     @Test
     public void testToString02() {
         setUp("bufferSize=12, anotherKey02=coolValue02", 12);
 
-        assertEquals("The string is not correct.", "bufferSize=12, anotherKey02=coolValue02", manager.toString());
+        assertEquals("bufferSize=12, anotherKey02=coolValue02", manager.toString(), "The string is not correct.");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/ColumnConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/ColumnConfigTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnConfigTest {
 
@@ -31,7 +31,7 @@ public class ColumnConfigTest {
     public void testNullNameNoConfig() {
         final ColumnConfig config = ColumnConfig.newBuilder().setPattern("%l").build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -42,7 +42,7 @@ public class ColumnConfigTest {
                 .setLiteral("literal")
                 .build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -53,7 +53,7 @@ public class ColumnConfigTest {
                 .setEventTimestamp(true)
                 .build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -64,14 +64,14 @@ public class ColumnConfigTest {
                 .setEventTimestamp(true)
                 .build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
     public void testNoSettingNoConfig01() {
         final ColumnConfig config = ColumnConfig.newBuilder().setName("col").build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -81,7 +81,7 @@ public class ColumnConfigTest {
                 .setEventTimestamp(false)
                 .build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ColumnConfigTest {
                 .setEventTimestamp(false)
                 .build();
 
-        assertNull("The result should be null.", config);
+        assertNull(config, "The result should be null.");
     }
 
     @Test
@@ -101,13 +101,13 @@ public class ColumnConfigTest {
         final ColumnConfig config =
                 ColumnConfig.newBuilder().setName("col").setEventTimestamp(true).build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col", config.getColumnName());
-        assertNull("The pattern should be null.", config.getLayout());
-        assertNull("The literal value should be null.", config.getLiteralValue());
-        assertTrue("The timestamp flag should be true.", config.isEventTimestamp());
-        assertFalse("The unicode flag should be false.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col", config.getColumnName(), "The column name is not correct.");
+        assertNull(config.getLayout(), "The pattern should be null.");
+        assertNull(config.getLiteralValue(), "The literal value should be null.");
+        assertTrue(config.isEventTimestamp(), "The timestamp flag should be true.");
+        assertFalse(config.isUnicode(), "The unicode flag should be false.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 
     @Test
@@ -119,13 +119,13 @@ public class ColumnConfigTest {
                 .setClob(true)
                 .build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col2", config.getColumnName());
-        assertNull("The pattern should be null.", config.getLayout());
-        assertNull("The literal value should be null.", config.getLiteralValue());
-        assertTrue("The timestamp flag should be true.", config.isEventTimestamp());
-        assertFalse("The unicode flag should be false.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col2", config.getColumnName(), "The column name is not correct.");
+        assertNull(config.getLayout(), "The pattern should be null.");
+        assertNull(config.getLiteralValue(), "The literal value should be null.");
+        assertTrue(config.isEventTimestamp(), "The timestamp flag should be true.");
+        assertFalse(config.isUnicode(), "The unicode flag should be false.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 
     @Test
@@ -133,14 +133,14 @@ public class ColumnConfigTest {
         final ColumnConfig config =
                 ColumnConfig.newBuilder().setName("col").setPattern("%l").build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col", config.getColumnName());
-        assertNotNull("The pattern should not be null.", config.getLayout());
-        assertEquals("The pattern is not correct.", "%l", config.getLayout().toString());
-        assertNull("The literal value should be null.", config.getLiteralValue());
-        assertFalse("The timestamp flag should be false.", config.isEventTimestamp());
-        assertTrue("The unicode flag should be true.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col", config.getColumnName(), "The column name is not correct.");
+        assertNotNull(config.getLayout(), "The pattern should not be null.");
+        assertEquals("%l", config.getLayout().toString(), "The pattern is not correct.");
+        assertNull(config.getLiteralValue(), "The literal value should be null.");
+        assertFalse(config.isEventTimestamp(), "The timestamp flag should be false.");
+        assertTrue(config.isUnicode(), "The unicode flag should be true.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 
     @Test
@@ -154,17 +154,14 @@ public class ColumnConfigTest {
                 .setClob(true)
                 .build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col2", config.getColumnName());
-        assertNotNull("The pattern should not be null.", config.getLayout());
-        assertEquals(
-                "The pattern is not correct.",
-                "%X{id} %level",
-                config.getLayout().toString());
-        assertNull("The literal value should be null.", config.getLiteralValue());
-        assertFalse("The timestamp flag should be false.", config.isEventTimestamp());
-        assertFalse("The unicode flag should be false.", config.isUnicode());
-        assertTrue("The clob flag should be true.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col2", config.getColumnName(), "The column name is not correct.");
+        assertNotNull(config.getLayout(), "The pattern should not be null.");
+        assertEquals("%X{id} %level", config.getLayout().toString(), "The pattern is not correct.");
+        assertNull(config.getLiteralValue(), "The literal value should be null.");
+        assertFalse(config.isEventTimestamp(), "The timestamp flag should be false.");
+        assertFalse(config.isUnicode(), "The unicode flag should be false.");
+        assertTrue(config.isClob(), "The clob flag should be true.");
     }
 
     @Test
@@ -178,17 +175,14 @@ public class ColumnConfigTest {
                 .setClob(false)
                 .build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col3", config.getColumnName());
-        assertNotNull("The pattern should not be null.", config.getLayout());
-        assertEquals(
-                "The pattern is not correct.",
-                "%X{id} %level",
-                config.getLayout().toString());
-        assertNull("The literal value should be null.", config.getLiteralValue());
-        assertFalse("The timestamp flag should be false.", config.isEventTimestamp());
-        assertTrue("The unicode flag should be true.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col3", config.getColumnName(), "The column name is not correct.");
+        assertNotNull(config.getLayout(), "The pattern should not be null.");
+        assertEquals("%X{id} %level", config.getLayout().toString(), "The pattern is not correct.");
+        assertNull(config.getLiteralValue(), "The literal value should be null.");
+        assertFalse(config.isEventTimestamp(), "The timestamp flag should be false.");
+        assertTrue(config.isUnicode(), "The unicode flag should be true.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 
     @Test
@@ -198,14 +192,14 @@ public class ColumnConfigTest {
                 .setLiteral("literalValue01")
                 .build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col", config.getColumnName());
-        assertNull("The pattern should be null.", config.getLayout());
-        assertNotNull("The literal value should be null.", config.getLiteralValue());
-        assertEquals("The literal value is not correct.", "literalValue01", config.getLiteralValue());
-        assertFalse("The timestamp flag should be false.", config.isEventTimestamp());
-        assertFalse("The unicode flag should be false.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col", config.getColumnName(), "The column name is not correct.");
+        assertNull(config.getLayout(), "The pattern should be null.");
+        assertNotNull(config.getLiteralValue(), "The literal value should be null.");
+        assertEquals("literalValue01", config.getLiteralValue(), "The literal value is not correct.");
+        assertFalse(config.isEventTimestamp(), "The timestamp flag should be false.");
+        assertFalse(config.isUnicode(), "The unicode flag should be false.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 
     @Test
@@ -217,13 +211,13 @@ public class ColumnConfigTest {
                 .setClob(true)
                 .build();
 
-        assertNotNull("The result should not be null.", config);
-        assertEquals("The column name is not correct.", "col2", config.getColumnName());
-        assertNull("The pattern should be null.", config.getLayout());
-        assertNotNull("The literal value should be null.", config.getLiteralValue());
-        assertEquals("The literal value is not correct.", "USER1.MY_SEQUENCE.NEXT", config.getLiteralValue());
-        assertFalse("The timestamp flag should be false.", config.isEventTimestamp());
-        assertFalse("The unicode flag should be false.", config.isUnicode());
-        assertFalse("The clob flag should be false.", config.isClob());
+        assertNotNull(config, "The result should not be null.");
+        assertEquals("col2", config.getColumnName(), "The column name is not correct.");
+        assertNull(config.getLayout(), "The pattern should be null.");
+        assertNotNull(config.getLiteralValue(), "The literal value should be null.");
+        assertEquals("USER1.MY_SEQUENCE.NEXT", config.getLiteralValue(), "The literal value is not correct.");
+        assertFalse(config.isEventTimestamp(), "The timestamp flag should be false.");
+        assertFalse(config.isUnicode(), "The unicode flag should be false.");
+        assertFalse(config.isClob(), "The clob flag should be false.");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/DriverManagerH2ConnectionSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/DriverManagerH2ConnectionSourceTest.java
@@ -20,8 +20,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.test.appender.db.jdbc.JdbcH2TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
 
@@ -40,7 +40,7 @@ public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
                 .build();
         // @formatter:on
         try (final Connection conn = source.getConnection()) {
-            Assert.assertFalse(conn.isClosed());
+            Assertions.assertFalse(conn.isClosed());
         }
     }
 
@@ -54,7 +54,7 @@ public class DriverManagerH2ConnectionSourceTest extends AbstractH2Test {
                 .build();
         // @formatter:on
         try (final Connection conn = source.getConnection()) {
-            Assert.assertFalse(conn.isClosed());
+            Assertions.assertFalse(conn.isClosed());
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/FactoryMethodConnectionSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/FactoryMethodConnectionSourceTest.java
@@ -16,29 +16,25 @@
  */
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
+@LoggerContextSource("log4j-fatalOnly.xml")
 public class FactoryMethodConnectionSourceTest {
     private static final ThreadLocal<Object> holder = new ThreadLocal<>();
-    private static final String CONFIG = "log4j-fatalOnly.xml";
 
-    @ClassRule
-    public static LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
-    @After
+    @AfterEach
     public void tearDown() {
         holder.remove();
     }
@@ -47,8 +43,7 @@ public class FactoryMethodConnectionSourceTest {
     public void testNoClassName() {
         final FactoryMethodConnectionSource source =
                 FactoryMethodConnectionSource.createConnectionSource(null, "method");
-
-        assertNull("The connection source should be null.", source);
+        assertNull(source, "The connection source should be null.");
     }
 
     @Test
@@ -56,7 +51,7 @@ public class FactoryMethodConnectionSourceTest {
         final FactoryMethodConnectionSource source =
                 FactoryMethodConnectionSource.createConnectionSource("someClass", null);
 
-        assertNull("The connection source should be null.", source);
+        assertNull(source, "The connection source should be null.");
     }
 
     @Test
@@ -64,7 +59,7 @@ public class FactoryMethodConnectionSourceTest {
         final FactoryMethodConnectionSource source =
                 FactoryMethodConnectionSource.createConnectionSource("org.apache.BadClass", "factoryMethod");
 
-        assertNull("The connection source should be null.", source);
+        assertNull(source, "The connection source should be null.");
     }
 
     @Test
@@ -72,7 +67,7 @@ public class FactoryMethodConnectionSourceTest {
         final FactoryMethodConnectionSource source = FactoryMethodConnectionSource.createConnectionSource(
                 this.getClass().getName(), "factoryMethod");
 
-        assertNull("The connection source should be null.", source);
+        assertNull(source, "The connection source should be null.");
     }
 
     @Test
@@ -80,7 +75,7 @@ public class FactoryMethodConnectionSourceTest {
         final FactoryMethodConnectionSource source = FactoryMethodConnectionSource.createConnectionSource(
                 BadReturnTypeFactory.class.getName(), "factoryMethod01");
 
-        assertNull("The connection source should be null.", source);
+        assertNull(source, "The connection source should be null.");
     }
 
     @Test
@@ -96,14 +91,14 @@ public class FactoryMethodConnectionSourceTest {
             final FactoryMethodConnectionSource source = FactoryMethodConnectionSource.createConnectionSource(
                     DataSourceFactory.class.getName(), "factoryMethod02");
 
-            assertNotNull("The connection source should not be null.", source);
+            assertNotNull(source, "The connection source should not be null.");
             assertEquals(
-                    "The toString value is not correct.",
                     "factory{ public static javax.sql.DataSource[" + dataSource + "] "
                             + DataSourceFactory.class.getName() + ".factoryMethod02() }",
-                    source.toString());
-            assertSame("The connection is not correct (1).", connection1, source.getConnection());
-            assertSame("The connection is not correct (2).", connection2, source.getConnection());
+                    source.toString(),
+                    "The toString value is not correct.");
+            assertSame(connection1, source.getConnection(), "The connection is not correct (1).");
+            assertSame(connection2, source.getConnection(), "The connection is not correct (2).");
         }
     }
 
@@ -116,14 +111,14 @@ public class FactoryMethodConnectionSourceTest {
             final FactoryMethodConnectionSource source = FactoryMethodConnectionSource.createConnectionSource(
                     ConnectionFactory.class.getName(), "anotherMethod03");
 
-            assertNotNull("The connection source should not be null.", source);
+            assertNotNull(source, "The connection source should not be null.");
             assertEquals(
-                    "The toString value is not correct.",
                     "factory{ public static java.sql.Connection " + ConnectionFactory.class.getName()
                             + ".anotherMethod03() }",
-                    source.toString());
-            assertSame("The connection is not correct (1).", connection, source.getConnection());
-            assertSame("The connection is not correct (2).", connection, source.getConnection());
+                    source.toString(),
+                    "The toString value is not correct.");
+            assertSame(connection, source.getConnection(), "The connection is not correct (1).");
+            assertSame(connection, source.getConnection(), "The connection is not correct (2).");
         }
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderH2DataSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderH2DataSourceTest.java
@@ -19,19 +19,19 @@ package org.apache.logging.log4j.core.appender.db.jdbc;
 import java.io.IOException;
 import org.apache.logging.log4j.core.test.appender.db.jdbc.JdbcH2TestHelper;
 import org.apache.logging.log4j.core.test.junit.JdbcRule;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  *
  */
 public class JdbcAppenderH2DataSourceTest extends AbstractJdbcAppenderDataSourceTest {
 
-    @Before
+    @BeforeEach
     public void afterEachDeleteDir() throws IOException {
         JdbcH2TestHelper.deleteDir();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEachDeleteDir() throws IOException {
         JdbcH2TestHelper.deleteDir();
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderH2FactoryMethodTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderH2FactoryMethodTest.java
@@ -21,7 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.apache.logging.log4j.core.test.appender.db.jdbc.JdbcH2TestHelper;
 import org.apache.logging.log4j.core.test.junit.JdbcRule;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  *
@@ -39,12 +39,12 @@ public class JdbcAppenderH2FactoryMethodTest extends AbstractJdbcAppenderFactory
                 "h2");
     }
 
-    @Before
+    @BeforeEach
     public void afterEachDeleteDir() throws IOException {
         JdbcH2TestHelper.deleteDir();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEachDeleteDir() throws IOException {
         JdbcH2TestHelper.deleteDir();
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderStringSubstitutionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppenderStringSubstitutionTest.java
@@ -16,11 +16,14 @@
  */
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 public class JdbcAppenderStringSubstitutionTest {
 
@@ -31,23 +34,19 @@ public class JdbcAppenderStringSubstitutionTest {
         System.setProperty(KEY, VALUE);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.getProperties().remove(KEY);
     }
 
-    @Rule
-    public final LoggerContextRule rule =
-            new LoggerContextRule("org/apache/logging/log4j/core/appender/db/jdbc/log4j2-jdbc-string-substitution.xml");
-
     @Test
-    public void test() throws Exception {
-        final JdbcAppender appender = rule.getAppender("databaseAppender", JdbcAppender.class);
-        Assert.assertNotNull(appender);
+    @LoggerContextSource("org/apache/logging/log4j/core/appender/db/jdbc/log4j2-jdbc-string-substitution.xml")
+    public void test(@Named("databaseAppender") JdbcAppender appender) throws Exception {
+        assertNotNull(appender);
         final JdbcDatabaseManager manager = appender.getManager();
-        Assert.assertNotNull(manager);
+        assertNotNull(manager);
         final String sqlStatement = manager.getSqlStatement();
-        Assert.assertFalse(sqlStatement, sqlStatement.contains(KEY));
-        Assert.assertTrue(sqlStatement, sqlStatement.contains(VALUE));
+        assertFalse(sqlStatement.contains(KEY), sqlStatement);
+        assertTrue(sqlStatement.contains(VALUE), sqlStatement);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderCloseTimeoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderCloseTimeoutTest.java
@@ -22,15 +22,16 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-@Category(Appenders.Kafka.class)
+@Tag("Appenders.Kafka")
+@LoggerContextSource(value = "KafkaAppenderCloseTimeoutTest.xml")
 public class KafkaAppenderCloseTimeoutTest {
 
     private static final Serializer<byte[]> SERIALIZER = new ByteArraySerializer();
@@ -65,22 +66,19 @@ public class KafkaAppenderCloseTimeoutTest {
                 }
             };
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @BeforeAll
+    public static void setUpAll() throws Exception {
         KafkaManager.producerFactory = config -> kafka;
     }
 
-    @Rule
-    public LoggerContextRule ctx = new LoggerContextRule("KafkaAppenderCloseTimeoutTest.xml");
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         kafka.clear();
     }
 
-    @Test(timeout = 2000)
-    public void testClose() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppender");
+    @Test
+    @Timeout(2000)
+    public void testClose(@Named("KafkaAppender") final Appender appender) throws Exception {
         appender.stop();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender.mom.kafka;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -40,17 +40,16 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.test.junit.SerialUtil;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Kafka.class)
+@Tag("Appenders.Kafka")
 public class KafkaAppenderTest {
 
     private static final Serializer<byte[]> SERIALIZER = new ByteArraySerializer();
@@ -101,22 +100,19 @@ public class KafkaAppenderTest {
                 .build();
     }
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @BeforeAll
+    public static void setUpAll() throws Exception {
         KafkaManager.producerFactory = config -> kafka;
     }
 
-    @Rule
-    public LoggerContextRule ctx = new LoggerContextRule("KafkaAppenderTest.xml");
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         kafka.clear();
     }
 
     @Test
-    public void testAppendWithLayout() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithLayout");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppendWithLayout(@Named("KafkaAppenderWithLayout") final Appender appender) throws Exception {
         appender.append(createLogEvent());
         final List<ProducerRecord<byte[], byte[]>> history = kafka.history();
         assertEquals(1, history.size());
@@ -128,8 +124,9 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAppendWithSerializedLayout() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithSerializedLayout");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppendWithSerializedLayout(@Named("KafkaAppenderWithSerializedLayout") final Appender appender)
+            throws Exception {
         final LogEvent logEvent = createLogEvent();
         appender.append(logEvent);
         final List<ProducerRecord<byte[], byte[]>> history = kafka.history();
@@ -144,8 +141,8 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAsyncAppend() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("AsyncKafkaAppender");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAsyncAppend(@Named("AsyncKafkaAppender") final Appender appender) throws Exception {
         appender.append(createLogEvent());
         final List<ProducerRecord<byte[], byte[]>> history = kafka.history();
         assertEquals(1, history.size());
@@ -157,8 +154,8 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAppendWithKey() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithKey");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppendWithKey(@Named("KafkaAppenderWithKey") final Appender appender) throws Exception {
         final LogEvent logEvent = createLogEvent();
         appender.append(logEvent);
         final List<ProducerRecord<byte[], byte[]>> history = kafka.history();
@@ -173,8 +170,8 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAppendWithKeyLookup() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithKeyLookup");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppendWithKeyLookup(@Named("KafkaAppenderWithKeyLookup") final Appender appender) throws Exception {
         final LogEvent logEvent = createLogEvent();
         final Date date = new Date();
         final SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy");
@@ -191,10 +188,10 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAppendWithRetryCount() {
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppendWithRetryCount(@Named("KafkaAppenderWithRetryCount") final Appender appender) {
         try {
             ThreadContext.put("KafkaAppenderWithRetryCount", "true");
-            final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithRetryCount");
             final LogEvent logEvent = createLogEvent();
             appender.append(logEvent);
 
@@ -208,8 +205,9 @@ public class KafkaAppenderTest {
     }
 
     @Test
-    public void testAppenderNoEventTimestamp() throws Exception {
-        final Appender appender = ctx.getRequiredAppender("KafkaAppenderNoEventTimestamp");
+    @LoggerContextSource("KafkaAppenderTest.xml")
+    public void testAppenderNoEventTimestamp(@Named("KafkaAppenderNoEventTimestamp") final Appender appender)
+            throws Exception {
         final LogEvent logEvent = createLogEvent();
         appender.append(logEvent);
         final List<ProducerRecord<byte[], byte[]>> history = kafka.history();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaManagerProducerThreadLeakTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaManagerProducerThreadLeakTest.java
@@ -19,9 +19,8 @@ package org.apache.logging.log4j.core.appender.mom.kafka;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.Test;
  *
  * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-2916">LOG4J2-2916</a>
  */
-@Category(Appenders.Kafka.class)
+@Tag("Appenders.Kafka")
 @LoggerContextSource("KafkaManagerProducerThreadLeakTest.xml")
 class KafkaManagerProducerThreadLeakTest {
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppenderTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.logging.log4j.core.appender.nosql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NoSqlAppenderTest {
 
     @Mock
@@ -35,18 +35,18 @@ public class NoSqlAppenderTest {
     public void testNoProvider() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("myName01", null, null, null, null);
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
     public void testProvider() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("myName01", null, null, null, provider);
 
-        assertNotNull("The appender should not be null.", appender);
+        assertNotNull(appender, "The appender should not be null.");
         assertEquals(
-                "The toString value is not correct.",
                 "myName01{ manager=noSqlManager{ description=myName01, bufferSize=0, provider=" + provider + " } }",
-                appender.toString());
+                appender.toString(),
+                "The toString value is not correct.");
 
         appender.stop();
     }
@@ -55,12 +55,12 @@ public class NoSqlAppenderTest {
     public void testProviderBuffer() {
         final NoSqlAppender appender = NoSqlAppender.createAppender("anotherName02", null, null, "25", provider);
 
-        assertNotNull("The appender should not be null.", appender);
+        assertNotNull(appender, "The appender should not be null.");
         assertEquals(
-                "The toString value is not correct.",
                 "anotherName02{ manager=noSqlManager{ description=anotherName02, bufferSize=25, provider=" + provider
                         + " } }",
-                appender.toString());
+                appender.toString(),
+                "The toString value is not correct.");
 
         appender.stop();
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RandomRollingAppenderOnStartupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RandomRollingAppenderOnStartupTest.java
@@ -16,57 +16,36 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
+@LoggerContextSource
 public class RandomRollingAppenderOnStartupTest {
 
     private static final String DIR = "target/onStartup";
 
-    private Logger logger;
-
-    @Parameterized.Parameters(name = "{0} \u2192 {1}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { //
-            // @formatter:off
-            {"log4j-test5.xml"}, {"log4j-test5.xml"},
-        });
-        // @formatter:on
+    public static Stream<Arguments> data() {
+        return Stream.of(Arguments.of("log4j-test5.xml"), Arguments.of("log4j-test5.xml"));
     }
 
-    @Rule
-    public LoggerContextRule loggerContextRule;
-
-    public RandomRollingAppenderOnStartupTest(final String configFile) {
-        this.loggerContextRule = LoggerContextRule.createShutdownTimeoutLoggerContextRule(configFile);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        this.logger = this.loggerContextRule.getLogger(RandomRollingAppenderOnStartupTest.class.getName());
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         if (Files.exists(Paths.get("target/onStartup"))) {
             try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
                 for (final Path path : directoryStream) {
@@ -77,27 +56,33 @@ public class RandomRollingAppenderOnStartupTest {
         }
     }
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @AfterAll
+    public static void afterAll() throws Exception {
         long size = 0;
-        try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
-            for (final Path path : directoryStream) {
-                if (size == 0) {
-                    size = Files.size(path);
-                } else {
-                    final long fileSize = Files.size(path);
-                    assertTrue(
-                            "Expected size: " + size + " Size of " + path.getFileName() + ": " + fileSize,
-                            size == fileSize);
+        if (Files.exists(Paths.get(DIR))) {
+            try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
+                for (final Path path : directoryStream) {
+                    if (size == 0) {
+                        size = Files.size(path);
+                    } else {
+                        final long fileSize = Files.size(path);
+                        assertTrue(
+                                size == fileSize,
+                                "Expected size: " + size + " Size of " + path.getFileName() + ": " + fileSize);
+                    }
+                    Files.delete(path);
                 }
-                Files.delete(path);
+                Files.delete(Paths.get(DIR));
             }
-            Files.delete(Paths.get(DIR));
         }
     }
 
-    @Test
-    public void testAppender() throws Exception {
+    @ParameterizedTest(name = "{0} \u2192 {1}")
+    @MethodSource("data")
+    public void testAppender(String configFile) throws Exception {
+        LoggerContext loggerContext = new LoggerContext(configFile);
+        Logger logger = loggerContext.getLogger(RandomRollingAppenderOnStartupTest.class.getName());
+
         for (int i = 0; i < 100; ++i) {
             logger.debug("This is test message number " + i);
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
@@ -18,42 +18,41 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Random;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-1804.
  */
+@LoggerContextSource(value = "log4j-rolling-cron-and-size-lookup.xml", timeout = 10)
 public class RollingAppenderCronAndSizeLookupTest {
 
     private static final String CONFIG = "log4j-rolling-cron-and-size-lookup.xml";
 
     private static final String DIR = "target/rolling-cron-size-lookup";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderCronAndSizeLookupTest.class.getName());
     }
 
@@ -69,7 +68,7 @@ public class RollingAppenderCronAndSizeLookupTest {
         }
         Thread.sleep(50);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         Arrays.sort(files);
         assertNotNull(files);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
@@ -31,15 +31,14 @@ import java.util.Random;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-1804.
  */
-@LoggerContextSource(value = "log4j-rolling-cron-and-size-lookup.xml", timeout = 10)
 public class RollingAppenderCronAndSizeLookupTest {
 
     private static final String CONFIG = "log4j-rolling-cron-and-size-lookup.xml";
@@ -47,7 +46,11 @@ public class RollingAppenderCronAndSizeLookupTest {
     private static final String DIR = "target/rolling-cron-size-lookup";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
@@ -57,6 +60,7 @@ public class RollingAppenderCronAndSizeLookupTest {
     }
 
     @Test
+    @Timeout(10)
     public void testAppender() throws Exception {
         final Random rand = new Random();
         // Loop for 500 times with a 5ms wait guarantees at least 2 time based rollovers.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeLookupTest.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -60,7 +59,6 @@ public class RollingAppenderCronAndSizeLookupTest {
     }
 
     @Test
-    @Timeout(10)
     public void testAppender() throws Exception {
         final Random rand = new Random();
         // Loop for 500 times with a 5ms wait guarantees at least 2 time based rollovers.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -59,7 +58,6 @@ public class RollingAppenderCronAndSizeTest {
     }
 
     @Test
-    @Timeout(10)
     public void testAppender() throws Exception {
         final Random rand = new Random();
         for (int j = 0; j < 100; ++j) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
@@ -29,31 +29,28 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Random;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-1804.
  */
+@LoggerContextSource(value = "log4j-rolling-cron-and-size.xml", timeout = 10)
 public class RollingAppenderCronAndSizeTest {
-
-    private static final String CONFIG = "log4j-rolling-cron-and-size.xml";
 
     private static final String DIR = "target/rolling-cron-size";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
-
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderCronAndSizeTest.class.getName());
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronAndSizeTest.java
@@ -31,23 +31,27 @@ import java.util.Random;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-1804.
  */
-@LoggerContextSource(value = "log4j-rolling-cron-and-size.xml", timeout = 10)
 public class RollingAppenderCronAndSizeTest {
 
+    private static final String CONFIG = "log4j-rolling-cron-and-size.xml";
     private static final String DIR = "target/rolling-cron-size";
 
     private Logger logger;
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @BeforeEach
     public void setUp(final LoggerContext loggerContextRule) throws Exception {
@@ -55,6 +59,7 @@ public class RollingAppenderCronAndSizeTest {
     }
 
     @Test
+    @Timeout(10)
     public void testAppender() throws Exception {
         final Random rand = new Random();
         for (int j = 0; j < 100; ++j) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
@@ -29,15 +29,14 @@ import java.util.Random;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-cron-every2-direct.xml", timeout = 10)
 public class RollingAppenderCronEvery2DirectTest {
 
     private static final String CONFIG = "log4j-rolling-cron-every2-direct.xml";
@@ -45,9 +44,14 @@ public class RollingAppenderCronEvery2DirectTest {
     private static final int LOOP_COUNT = 100;
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2DirectTest.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
@@ -20,38 +20,37 @@ import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.security.SecureRandom;
 import java.util.Random;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-cron-every2-direct.xml", timeout = 10)
 public class RollingAppenderCronEvery2DirectTest {
 
     private static final String CONFIG = "log4j-rolling-cron-every2-direct.xml";
     private static final String DIR = "target/rolling-cron-every2Direct";
     private static final int LOOP_COUNT = 100;
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2DirectTest.class.getName());
         final long end = System.currentTimeMillis() + 5000;
         final Random rand = new SecureRandom();
         rand.setSeed(end);
@@ -61,7 +60,7 @@ public class RollingAppenderCronEvery2DirectTest {
             Thread.sleep(10 * rand.nextInt(100));
         } while (System.currentTimeMillis() < end);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
 
         final int MAX_TRIES = 20;
         final Matcher<File[]> hasGzippedFile = hasItemInArray(that(hasName(that(endsWith(".gz")))));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2DirectTest.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -51,7 +50,6 @@ public class RollingAppenderCronEvery2DirectTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2DirectTest.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -52,7 +51,6 @@ public class RollingAppenderCronEvery2Test {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2Test.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
@@ -29,15 +29,14 @@ import java.util.Random;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-cron-every2.xml", timeout = 10)
 public class RollingAppenderCronEvery2Test {
 
     private static final String CONFIG = "log4j-rolling-cron-every2.xml";
@@ -46,9 +45,14 @@ public class RollingAppenderCronEvery2Test {
     private static final int LOOP_COUNT = 100;
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2Test.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronEvery2Test.java
@@ -20,22 +20,24 @@ import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.security.SecureRandom;
 import java.util.Random;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-cron-every2.xml", timeout = 10)
 public class RollingAppenderCronEvery2Test {
 
     private static final String CONFIG = "log4j-rolling-cron-every2.xml";
@@ -43,18 +45,15 @@ public class RollingAppenderCronEvery2Test {
     private static final String FILE = "target/rolling-cron-every2/rollingtest.log";
     private static final int LOOP_COUNT = 100;
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderCronEvery2Test.class.getName());
         final File file = new File(FILE);
-        assertTrue("Log file does not exist", file.exists());
+        assertTrue(file.exists(), "Log file does not exist");
         final long end = System.currentTimeMillis() + 5000;
         final Random rand = new SecureRandom();
         rand.setSeed(end);
@@ -64,7 +63,7 @@ public class RollingAppenderCronEvery2Test {
             Thread.sleep(10 * rand.nextInt(100));
         } while (System.currentTimeMillis() < end);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
 
         final int MAX_TRIES = 20;
         final Matcher<File[]> hasGzippedFile = hasItemInArray(that(hasName(that(endsWith(".gz")))));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronOnStartupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronOnStartupTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,9 +31,9 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -80,18 +80,18 @@ public class RollingAppenderCronOnStartupTest {
         ps = new PrintStream(new FileOutputStream(rolled));
         ps.println("This is a line 1");
         ps.close();
-        assertTrue("Log file does not exist", file.exists());
-        assertTrue("Log file does not exist", rolled.exists());
+        assertTrue(file.exists(), "Log file does not exist");
+        assertTrue(rolled.exists(), "Log file does not exist");
         final LoggerContext lc = Configurator.initialize("Test", CONFIG);
         final Logger logger = lc.getLogger(RollingAppenderCronOnStartupTest.class);
         logger.info("This is line 3");
         final File[] files = dir.listFiles();
-        assertNotNull("No files", files);
-        assertEquals("Unexpected number of files. Expected 2 but found " + files.length, 2, files.length);
+        assertNotNull(files, "No files");
+        assertEquals(2, files.length, "Unexpected number of files. Expected 2 but found " + files.length);
         List<String> lines = Files.readAllLines(file.toPath());
-        assertEquals("Unexpected number of lines. Expected 2: Actual: " + lines.size(), 2, lines.size());
+        assertEquals(2, lines.size(), "Unexpected number of lines. Expected 2: Actual: " + lines.size());
         lines = Files.readAllLines(rolled.toPath());
-        assertEquals("Unexpected number of lines. Expected 1: Actual: " + lines.size(), 1, lines.size());
+        assertEquals(1, lines.size(), "Unexpected number of lines. Expected 1: Actual: " + lines.size());
     }
 
     private static void cleanDir(final File dir) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronOnceADayTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronOnceADayTest.java
@@ -19,10 +19,10 @@ package org.apache.logging.log4j.core.appender.rolling;
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.FileSystems;
@@ -30,15 +30,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Calendar;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.hamcrest.Matcher;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * This test currently takes about a minute to run.
@@ -57,8 +57,8 @@ public class RollingAppenderCronOnceADayTest {
     private static String cronExpression;
     private static long remainingTime;
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         final Path src = FileSystems.getDefault().getPath(TARGET_TEST_CLASSES, CONFIG);
         String content = new String(Files.readAllBytes(src), UTF_8);
         final Calendar cal = Calendar.getInstance();
@@ -71,26 +71,28 @@ public class RollingAppenderCronOnceADayTest {
         StatusLogger.getLogger().debug("Cron expression will be " + cronExpression + " in " + remainingTime + "ms");
     }
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG_TARGET);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG_TARGET,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderCronOnceADayTest.class.getName());
         final File file = new File(FILE);
-        assertTrue("Log file does not exist", file.exists());
+        assertTrue(file.exists(), "Log file does not exist");
         logger.debug("This is test message number 1, waiting for rolling");
 
-        final RollingFileAppender app = (RollingFileAppender)
-                loggerContextRule.getLoggerContext().getConfiguration().getAppender("RollingFile");
+        final RollingFileAppender app =
+                (RollingFileAppender) loggerContextRule.getConfiguration().getAppender("RollingFile");
         final TriggeringPolicy policy = app.getManager().getTriggeringPolicy();
-        assertNotNull("No triggering policy", policy);
-        assertTrue("Incorrect policy type", policy instanceof CronTriggeringPolicy);
+        assertNotNull(policy, "No triggering policy");
+        assertTrue(policy instanceof CronTriggeringPolicy, "Incorrect policy type");
         final CronExpression expression = ((CronTriggeringPolicy) policy).getCronExpression();
-        assertEquals("Incorrect cron expresion", cronExpression, expression.getCronExpression());
+        assertEquals(cronExpression, expression.getCronExpression(), "Incorrect cron expression");
         logger.debug("Cron expression will be {}", expression.getCronExpression());
 
         // force a reconfiguration
@@ -100,7 +102,7 @@ public class RollingAppenderCronOnceADayTest {
 
         Thread.sleep(remainingTime);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
 
         for (int i = 1; i < 5; i++) {
             logger.debug("Adding some more event {}", i);
@@ -115,7 +117,7 @@ public class RollingAppenderCronOnceADayTest {
             }
         }
 
-        assertNotEquals("No compressed files found", 0, count);
-        assertEquals("Multiple files found", 1, count);
+        assertNotEquals(0, count, "No compressed files found");
+        assertEquals(1, count, "Multiple files found");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
@@ -20,9 +20,9 @@ import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,39 +31,37 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-cron.xml", timeout = 10)
 public class RollingAppenderCronTest {
 
-    private static final String CONFIG = "log4j-rolling-cron.xml";
     private static final String DIR = "target/rolling-cron";
     private static final String FILE = "target/rolling-cron/rollingtest.log";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderCronTest.class.getName());
         final File file = new File(FILE);
-        assertTrue("Log file does not exist", file.exists());
+        assertTrue(file.exists(), "Log file does not exist");
         logger.debug("This is test message number 1");
         Thread.sleep(2500);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
 
         final int MAX_TRIES = 20;
         final Matcher<File[]> hasGzippedFile = hasItemInArray(that(hasName(that(endsWith(".gz")))));
@@ -94,12 +92,12 @@ public class RollingAppenderCronTest {
             logger.debug("Adding new event {}", i);
         }
         Thread.sleep(1000);
-        final RollingFileAppender app = (RollingFileAppender)
-                loggerContextRule.getLoggerContext().getConfiguration().getAppender("RollingFile");
+        final RollingFileAppender app =
+                (RollingFileAppender) loggerContextRule.getConfiguration().getAppender("RollingFile");
         final TriggeringPolicy policy = app.getManager().getTriggeringPolicy();
-        assertNotNull("No triggering policy", policy);
-        assertTrue("Incorrect policy type", policy instanceof CronTriggeringPolicy);
+        assertNotNull(policy, "No triggering policy");
+        assertTrue(policy instanceof CronTriggeringPolicy, "Incorrect policy type");
         final CronExpression expression = ((CronTriggeringPolicy) policy).getCronExpression();
-        assertTrue("Incorrect triggering policy", expression.getCronExpression().equals("* * * ? * *"));
+        assertTrue(expression.getCronExpression().equals("* * * ? * *"), "Incorrect triggering policy");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
@@ -34,25 +34,30 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-cron.xml", timeout = 10)
 public class RollingAppenderCronTest {
 
+    private static final String CONFIG = "log4j-rolling-cron.xml";
     private static final String DIR = "target/rolling-cron";
     private static final String FILE = "target/rolling-cron/rollingtest.log";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronTest.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronTest.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -57,7 +56,6 @@ public class RollingAppenderCronTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // TODO Is there a better way to test than putting the thread to sleep all over the place?
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCronTest.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
@@ -16,35 +16,33 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-with-custom-delete.xml", timeout = 10)
 public class RollingAppenderCustomDeleteActionTest {
 
-    private static final String CONFIG = "log4j-rolling-with-custom-delete.xml";
     private static final String DIR = "target/rolling-with-delete/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
-        final Logger logger = loggerContextRule.getLogger();
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderCustomDeleteActionTest.class.getName());
         // Trigger the rollover
         for (int i = 0; i < 10; ++i) {
             // 30 chars per message: each message triggers a rollover
@@ -53,8 +51,8 @@ public class RollingAppenderCustomDeleteActionTest {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final int MAX_TRIES = 20;
         for (int i = 0; i < MAX_TRIES; i++) {
@@ -65,9 +63,9 @@ public class RollingAppenderCustomDeleteActionTest {
             if (files.length == 3) {
                 for (final File file : files) {
                     assertTrue(
-                            "test-4.log should have been deleted",
                             Arrays.asList("test-1.log", "test-2.log", "test-3.log")
-                                    .contains(file.getName()));
+                                    .contains(file.getName()),
+                            "test-4.log should have been deleted");
                 }
                 return; // test succeeded
             }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
@@ -25,22 +25,27 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-with-custom-delete.xml", timeout = 10)
 public class RollingAppenderCustomDeleteActionTest {
 
+    private static final String CONFIG = "log4j-rolling-with-custom-delete.xml";
     private static final String DIR = "target/rolling-with-delete/test";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCustomDeleteActionTest.class.getName());
         // Trigger the rollover

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCustomDeleteActionTest.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -45,7 +44,6 @@ public class RollingAppenderCustomDeleteActionTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Logger logger = loggerContextRule.getLogger(RollingAppenderCustomDeleteActionTest.class.getName());
         // Trigger the rollover

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
@@ -33,24 +33,29 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that sibling conditions are invoked in configured order.
  * This does not work for properties configurations. Use nested conditions instead.
  */
-@LoggerContextSource(value = "log4j-rolling-with-custom-delete-accum-count1.xml", timeout = 10)
 public class RollingAppenderDeleteAccumulatedCount1Test {
+    private static final String CONFIG = "log4j-rolling-with-custom-delete-accum-count1.xml";
     private static final String DIR = "target/rolling-with-delete-accum-count1/test";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -55,7 +54,6 @@ public class RollingAppenderDeleteAccumulatedCount1Test {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount1Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -31,36 +31,34 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that sibling conditions are invoked in configured order.
  * This does not work for properties configurations. Use nested conditions instead.
  */
+@LoggerContextSource(value = "log4j-rolling-with-custom-delete-accum-count1.xml", timeout = 10)
 public class RollingAppenderDeleteAccumulatedCount1Test {
-    private static final String CONFIG = "log4j-rolling-with-custom-delete-accum-count1.xml";
     private static final String DIR = "target/rolling-with-delete-accum-count1/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");
         final Path p3 = writeTextTo(DIR + "/my-3.log");
         final Path p4 = writeTextTo(DIR + "/my-4.log");
         final Path p5 = writeTextTo(DIR + "/my-5.log");
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteAccumulatedCount1Test.class.getName());
         for (int i = 0; i < 10; ++i) {
             updateLastModified(p1, p2, p3, p4, p5); // make my-*.log files most recent
 
@@ -70,8 +68,8 @@ public class RollingAppenderDeleteAccumulatedCount1Test {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         for (final File file : files) {
@@ -79,7 +77,7 @@ public class RollingAppenderDeleteAccumulatedCount1Test {
                     + FixedDateFormat.create(FixedFormat.ABSOLUTE).format(file.lastModified()));
         }
         final List<String> expected = Arrays.asList("my-1.log", "my-2.log", "my-3.log", "my-4.log", "my-5.log");
-        assertEquals(Arrays.toString(files), expected.size() + 6, files.length);
+        assertEquals(expected.size() + 6, files.length, Arrays.toString(files));
         for (final File file : files) {
             if (!expected.contains(file.getName()) && !file.getName().startsWith("test-")) {
                 fail("unexpected file" + file);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount2Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -31,12 +31,13 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests that sibling conditions are invoked in configured order.
@@ -46,21 +47,23 @@ public class RollingAppenderDeleteAccumulatedCount2Test {
     private static final String CONFIG = "log4j-rolling-with-custom-delete-accum-count2.xml";
     private static final String DIR = "target/rolling-with-delete-accum-count2/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");
         final Path p3 = writeTextTo(DIR + "/my-3.log");
         final Path p4 = writeTextTo(DIR + "/my-4.log");
         final Path p5 = writeTextTo(DIR + "/my-5.log");
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteAccumulatedCount2Test.class.getName());
         for (int i = 0; i < 10; ++i) {
             updateLastModified(p1, p2, p3, p4, p5); // make my-*.log files most recent
 
@@ -70,8 +73,8 @@ public class RollingAppenderDeleteAccumulatedCount2Test {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         for (final File file : files) {
@@ -80,7 +83,7 @@ public class RollingAppenderDeleteAccumulatedCount2Test {
         }
         // sometimes "test-9.log", sometimes "test-10.log" remains
         final List<String> expected = Arrays.asList("my-1.log", "my-2.log", "my-3.log", "my-4.log", "my-5.log");
-        assertEquals(Arrays.toString(files), expected.size() + 1, files.length);
+        assertEquals(expected.size() + 1, files.length, Arrays.toString(files));
         for (final File file : files) {
             if (!expected.contains(file.getName()) && !file.getName().startsWith("test-")) {
                 fail("unexpected file" + file);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedCount2Test.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -55,7 +54,6 @@ public class RollingAppenderDeleteAccumulatedCount2Test {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedSizeTest.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -45,7 +44,6 @@ public class RollingAppenderDeleteAccumulatedSizeTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
 
         final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteAccumulatedSizeTest.class.getName());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteAccumulatedSizeTest.java
@@ -16,18 +16,19 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -36,16 +37,18 @@ public class RollingAppenderDeleteAccumulatedSizeTest {
     private static final String CONFIG = "log4j-rolling-with-custom-delete-accum-size.xml";
     private static final String DIR = "target/rolling-with-delete-accum-size/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteAccumulatedSizeTest.class.getName());
         for (int i = 0; i < 10; ++i) {
             // 30 chars per message: each message triggers a rollover
             logger.debug("This is a test message number " + i); // 30 chars:
@@ -53,21 +56,21 @@ public class RollingAppenderDeleteAccumulatedSizeTest {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         for (final File file : files) {
             System.out.println(file + " (" + file.length() + "B) "
                     + FixedDateFormat.create(FixedFormat.ABSOLUTE).format(file.lastModified()));
         }
-        assertEquals(Arrays.toString(files), 4, files.length);
+        assertEquals(4, files.length, Arrays.toString(files));
         long total = 0;
         for (final File file : files) {
             // sometimes test-6.log remains
-            assertTrue("unexpected file " + file, file.getName().startsWith("test-"));
+            assertTrue(file.getName().startsWith("test-"), "unexpected file " + file);
             total += file.length();
         }
-        assertTrue("accumulatedSize=" + total, total <= 500);
+        assertTrue(total <= 500, "accumulatedSize=" + total);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteMaxDepthTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteMaxDepthTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -30,10 +30,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -43,21 +44,23 @@ public class RollingAppenderDeleteMaxDepthTest {
     private static final String CONFIG = "log4j-rolling-with-custom-delete-maxdepth.xml";
     private static final String DIR = "target/rolling-with-delete-depth/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // create some files that match the glob but exceed maxDepth
         final Path p1 = writeTextTo(DIR + "/1/test-4.log"); // glob="**/test-4.log"
         final Path p2 = writeTextTo(DIR + "/2/test-4.log");
         final Path p3 = writeTextTo(DIR + "/1/2/test-4.log");
         final Path p4 = writeTextTo(DIR + "/1/2/3/test-4.log");
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteMaxDepthTest.class.getName());
         for (int i = 0; i < 10; ++i) {
             // 30 chars per message: each message triggers a rollover
             logger.debug("This is a test message number " + i); // 30 chars:
@@ -65,20 +68,20 @@ public class RollingAppenderDeleteMaxDepthTest {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         final List<String> expected = Arrays.asList("1", "2", "test-1.log", "test-2.log", "test-3.log");
-        assertEquals(Arrays.toString(files), expected.size(), files.length);
+        assertEquals(expected.size(), files.length, Arrays.toString(files));
         for (final File file : files) {
-            assertTrue("test-4.log should have been deleted", expected.contains(file.getName()));
+            assertTrue(expected.contains(file.getName()), "test-4.log should have been deleted");
         }
 
-        assertTrue(p1 + " should not have been deleted", Files.exists(p1));
-        assertTrue(p2 + " should not have been deleted", Files.exists(p2));
-        assertTrue(p3 + " should not have been deleted", Files.exists(p3));
-        assertTrue(p4 + " should not have been deleted", Files.exists(p4));
+        assertTrue(Files.exists(p1), p1 + " should not have been deleted");
+        assertTrue(Files.exists(p2), p2 + " should not have been deleted");
+        assertTrue(Files.exists(p3), p3 + " should not have been deleted");
+        assertTrue(Files.exists(p4), p4 + " should not have been deleted");
     }
 
     private Path writeTextTo(final String location) throws IOException {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteMaxDepthTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteMaxDepthTest.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -52,7 +51,6 @@ public class RollingAppenderDeleteMaxDepthTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         // create some files that match the glob but exceed maxDepth
         final Path p1 = writeTextTo(DIR + "/1/test-4.log"); // glob="**/test-4.log"

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteNestedTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteNestedTest.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -54,7 +53,6 @@ public class RollingAppenderDeleteNestedTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteNestedTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteNestedTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -31,12 +31,13 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -45,21 +46,23 @@ public class RollingAppenderDeleteNestedTest {
     private static final String CONFIG = "log4j-rolling-with-custom-delete-nested.xml";
     private static final String DIR = "target/rolling-with-delete-nested/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Path p1 = writeTextTo(DIR + "/my-1.log"); // glob="test-*.log"
         final Path p2 = writeTextTo(DIR + "/my-2.log");
         final Path p3 = writeTextTo(DIR + "/my-3.log");
         final Path p4 = writeTextTo(DIR + "/my-4.log");
         final Path p5 = writeTextTo(DIR + "/my-5.log");
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteNestedTest.class.getName());
         for (int i = 0; i < 10; ++i) {
             updateLastModified(p1, p2, p3, p4, p5); // make my-*.log files most recent
 
@@ -69,8 +72,8 @@ public class RollingAppenderDeleteNestedTest {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         for (final File file : files) {
@@ -79,7 +82,7 @@ public class RollingAppenderDeleteNestedTest {
         }
 
         final List<String> expected = Arrays.asList("my-1.log", "my-2.log", "my-3.log", "my-4.log", "my-5.log");
-        assertEquals(Arrays.toString(files), expected.size() + 3, files.length);
+        assertEquals(expected.size() + 3, files.length, Arrays.toString(files));
         for (final File file : files) {
             if (!expected.contains(file.getName()) && !file.getName().startsWith("test-")) {
                 fail("unexpected file" + file);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptFri13thTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptFri13thTest.java
@@ -16,40 +16,43 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.File;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RollingAppenderDeleteScriptFri13thTest {
 
     private static final String CONFIG = "log4j-rolling-with-custom-delete-script-fri13th.xml";
     private static final String DIR = "target/rolling-with-delete-script-fri13th/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.SCRIPT_LANGUAGES, "Groovy, Javascript");
     }
 
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         LocalDate now = LocalDate.now();
         // Ignore on Friday 13th
         assumeFalse(now.getDayOfWeek() == DayOfWeek.FRIDAY && now.getDayOfMonth() == 13);
@@ -59,9 +62,9 @@ public class RollingAppenderDeleteScriptFri13thTest {
             final String day = i < 10 ? "0" + i : "" + i;
             new File(dir, "test-201511" + day + "-0.log").createNewFile();
         }
-        assertEquals("Dir " + DIR + " filecount", 30, dir.listFiles().length);
+        assertEquals(30, dir.listFiles().length, "Dir " + DIR + " filecount");
 
-        final Logger logger = loggerContextRule.getLogger();
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteScriptFri13thTest.class.getName());
         // Trigger the rollover
         while (dir.listFiles().length < 32) {
             // 60+ chars per message: each message should trigger a rollover
@@ -74,10 +77,10 @@ public class RollingAppenderDeleteScriptFri13thTest {
             System.out.println(file);
         }
         for (final File file : files) {
-            assertTrue(file.getName() + " starts with 'test-'", file.getName().startsWith("test-"));
-            assertTrue(file.getName() + " ends with '.log'", file.getName().endsWith(".log"));
+            assertTrue(file.getName().startsWith("test-"), file.getName() + " starts with 'test-'");
+            assertTrue(file.getName().endsWith(".log"), file.getName() + " ends with '.log'");
             final String strDate = file.getName().substring(5, 13);
-            assertFalse(file + " is not Fri 13th", strDate.endsWith("20151113"));
+            assertFalse(strDate.endsWith("20151113"), file + " is not Fri 13th");
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptFri13thTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptFri13thTest.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.Constants;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RollingAppenderDeleteScriptFri13thTest {
@@ -51,7 +50,6 @@ public class RollingAppenderDeleteScriptFri13thTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         LocalDate now = LocalDate.now();
         // Ignore on Friday 13th

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptTest.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -50,7 +49,6 @@ public class RollingAppenderDeleteScriptTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteScriptTest.class.getName());
         // Trigger the rollover

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDeleteScriptTest.java
@@ -16,17 +16,18 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -36,20 +37,22 @@ public class RollingAppenderDeleteScriptTest {
     private static final String CONFIG = "log4j-rolling-with-custom-delete-script.xml";
     private static final String DIR = "target/rolling-with-delete-script/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.SCRIPT_LANGUAGES, "Groovy, Javascript");
     }
 
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
-    public void testAppender() throws Exception {
-        final Logger logger = loggerContextRule.getLogger();
+    @Timeout(10)
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDeleteScriptTest.class.getName());
         // Trigger the rollover
         for (int i = 0; i < 10; ++i) {
             // 30 chars per message: each message triggers a rollover
@@ -58,19 +61,19 @@ public class RollingAppenderDeleteScriptTest {
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         for (final File file : files) {
             System.out.println(file);
         }
         for (final File file : files) {
-            assertTrue(file.getName() + " starts with 'test-'", file.getName().startsWith("test-"));
-            assertTrue(file.getName() + " ends with '.log'", file.getName().endsWith(".log"));
+            assertTrue(file.getName().startsWith("test-"), file.getName() + " starts with 'test-'");
+            assertTrue(file.getName().endsWith(".log"), file.getName() + " ends with '.log'");
             final String strIndex = file.getName().substring(5, file.getName().indexOf('.'));
             final int index = Integers.parseInt(strIndex);
-            assertTrue(file + " should have odd index", index % 2 == 1);
+            assertTrue(index % 2 == 1, file + " should have odd index");
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCustomDeleteActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCustomDeleteActionTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -38,18 +38,19 @@ public class RollingAppenderDirectCustomDeleteActionTest implements RolloverList
     private static final String CONFIG = "log4j-rolling-direct-with-custom-delete.xml";
     private static final String DIR = "target/rolling-direct-with-delete/test";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDirectCustomDeleteActionTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private boolean fileFound = false;
 
     @Test
-    public void testAppender() throws Exception {
-        final Logger logger = loggerContextRule.getLogger();
-        final RollingFileAppender app = loggerContextRule.getAppender("RollingFile");
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderDirectCustomDeleteActionTest.class.getName());
+        final RollingFileAppender app = loggerContextRule.getConfiguration().getAppender("RollingFile");
         assertNotNull(app, "No RollingFileAppender");
         app.getManager().addRolloverListener(this);
         // Trigger the rollover
@@ -60,8 +61,8 @@ public class RollingAppenderDirectCustomDeleteActionTest implements RolloverList
         Thread.sleep(100); // Allow time for rollover to complete
 
         final File dir = new File(DIR);
-        assertTrue("Dir " + DIR + " should exist", dir.exists());
-        assertTrue("Dir " + DIR + " should contain files", dir.listFiles().length > 0);
+        assertTrue(dir.exists(), "Dir " + DIR + " should exist");
+        assertTrue(dir.listFiles().length > 0, "Dir " + DIR + " should contain files");
 
         final File[] files = dir.listFiles();
         assertNotNull(files, "No fiels");
@@ -69,8 +70,8 @@ public class RollingAppenderDirectCustomDeleteActionTest implements RolloverList
         final long count = Arrays.stream(files)
                 .filter((f) -> f.getName().endsWith("test-4.log"))
                 .count();
-        assertTrue("Deleted file was not created", fileFound);
-        assertEquals("File count expected: 0, actual: " + count, 0, count);
+        assertTrue(fileFound, "Deleted file was not created");
+        assertEquals(0, count, "File count expected: 0, actual: " + count);
     }
 
     public static void main(final String[] args) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -71,7 +70,6 @@ public class RollingAppenderDirectWrite1906Test {
     }
 
     @Test
-    @Timeout(10)
     public void testAppender() throws Exception {
         final int count = 100;
         for (int i = 0; i < count; ++i) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
@@ -34,21 +34,21 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-direct-1906.xml", timeout = 10)
 public class RollingAppenderDirectWrite1906Test {
 
+    private static final String CONFIG = "log4j-rolling-direct-1906.xml";
     private static final String DIR = "target/rolling-direct-1906";
 
     private Logger logger;
@@ -59,7 +59,11 @@ public class RollingAppenderDirectWrite1906Test {
     }
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @BeforeEach
     public void setUp(final LoggerContext loggerContextRule) throws Exception {
@@ -67,6 +71,7 @@ public class RollingAppenderDirectWrite1906Test {
     }
 
     @Test
+    @Timeout(10)
     public void testAppender() throws Exception {
         final int count = 100;
         for (int i = 0; i < count; ++i) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWrite1906Test.java
@@ -18,12 +18,12 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,40 +32,37 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-direct-1906.xml", timeout = 10)
 public class RollingAppenderDirectWrite1906Test {
-
-    private static final String CONFIG = "log4j-rolling-direct-1906.xml";
 
     private static final String DIR = "target/rolling-direct-1906";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
-
     private Logger logger;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() throws Exception {
         StatusLogger.getLogger().registerListener(new NoopStatusListener());
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderDirectWrite1906Test.class.getName());
     }
 
@@ -78,7 +75,7 @@ public class RollingAppenderDirectWrite1906Test {
         }
         Thread.sleep(50);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         assertThat(files, hasItemInArray(that(hasName(that(endsWith(".log"))))));
@@ -92,12 +89,12 @@ public class RollingAppenderDirectWrite1906Test {
                 final String[] parts = line.split((" "));
                 final String expected = "rollingfile." + parts[0] + ".log";
 
-                assertEquals(logFileNameError(expected, actual), expected, actual);
+                assertEquals(expected, actual, logFileNameError(expected, actual));
                 ++found;
             }
             reader.close();
         }
-        assertEquals("Incorrect number of events read. Expected " + count + ", Actual " + found, count, found);
+        assertEquals(count, found, "Incorrect number of events read. Expected " + count + ", Actual " + found);
     }
 
     private String logFileNameError(final String expected, final String actual) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteStartupSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteStartupSizeTest.java
@@ -16,16 +16,20 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.test.junit.CleanFolders;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test LOG4J2-2485.
@@ -40,14 +44,8 @@ public class RollingAppenderDirectWriteStartupSizeTest {
 
     private static final String MESSAGE = "test message";
 
-    @Rule
-    public LoggerContextRule loggerContextRule = LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public CleanFolders cleanFolders = new CleanFolders(false, true, 10, DIR);
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         final Path log = Paths.get(DIR, FILE);
         if (Files.exists(log)) {
             Files.delete(log);
@@ -58,13 +56,25 @@ public class RollingAppenderDirectWriteStartupSizeTest {
         Files.write(log, MESSAGE.getBytes());
     }
 
+    @BeforeEach
+    @LoggerContextSource(value = CONFIG, timeout = 10)
+    public void setUp() throws Exception {
+        new CleanFolders(false, true, 10, DIR);
+    }
+
+    @AfterEach
+    @LoggerContextSource(value = CONFIG, timeout = 10)
+    public void teardown() throws Exception {
+        new CleanFolders(false, true, 10, DIR);
+    }
+
     @Test
-    public void testRollingFileAppenderWithReconfigure() throws Exception {
-        final RollingFileAppender rfAppender =
-                loggerContextRule.getRequiredAppender("RollingFile", RollingFileAppender.class);
+    @LoggerContextSource(value = CONFIG, timeout = 10)
+    public void testRollingFileAppenderWithReconfigure(@Named("RollingFile") RollingFileAppender rfAppender)
+            throws Exception {
         final RollingFileManager manager = rfAppender.getManager();
 
-        Assert.assertNotNull(manager);
-        Assert.assertEquals("Existing file size not preserved on startup", MESSAGE.getBytes().length, manager.size);
+        assertNotNull(manager);
+        assertEquals(MESSAGE.getBytes().length, manager.size, "Existing file size not preserved on startup");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -50,7 +49,6 @@ public class RollingAppenderDirectWriteWithFilenameTest {
     }
 
     @Test
-    @Timeout(10)
     public void testAppender(LoggerContext context) throws Exception {
         final File dir = new File(DIR);
         assertFalse(dir.exists(), "Directory created");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
@@ -16,41 +16,38 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j2-rolling-1833.xml", timeout = 10)
 public class RollingAppenderDirectWriteWithFilenameTest {
-
-    private static final String CONFIG = "log4j2-rolling-1833.xml";
 
     private static final String DIR = "target/rolling-1833";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
-
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderDirectWriteWithFilenameTest.class.getName());
     }
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(LoggerContext context) throws Exception {
         final File dir = new File(DIR);
-        assertFalse("Directory created", dir.exists());
+        assertFalse(dir.exists(), "Directory created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithFilenameTest.java
@@ -22,23 +22,27 @@ import java.io.File;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j2-rolling-1833.xml", timeout = 10)
 public class RollingAppenderDirectWriteWithFilenameTest {
 
+    private static final String CONFIG = "log4j2-rolling-1833.xml";
     private static final String DIR = "target/rolling-1833";
 
     private Logger logger;
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @BeforeEach
     public void setUp(final LoggerContext loggerContextRule) throws Exception {
@@ -46,6 +50,7 @@ public class RollingAppenderDirectWriteWithFilenameTest {
     }
 
     @Test
+    @Timeout(10)
     public void testAppender(LoggerContext context) throws Exception {
         final File dir = new File(DIR);
         assertFalse(dir.exists(), "Directory created");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
@@ -36,34 +36,45 @@ import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.IOUtils;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for LOG4J2-2760
  */
+@LoggerContextSource(timeout = 10)
 public class RollingAppenderDirectWriteWithHtmlLayoutTest {
 
     private static final String DIR = "target/rolling-direct-htmlLayout";
 
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+
+    private Configuration config;
+
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
+        this.config = loggerContextRule.getConfiguration();
+    }
+
     @Test
-    @LoggerContextSource(DIR)
     public void testRollingFileAppenderWithHtmlLayout() throws Exception {
         checkAppenderWithHtmlLayout(true);
     }
 
     @Test
-    @LoggerContextSource(DIR)
     public void testRollingFileAppenderWithHtmlLayoutNoAppend() throws Exception {
         checkAppenderWithHtmlLayout(false);
     }
 
     private void checkAppenderWithHtmlLayout(final boolean append) throws InterruptedException, IOException {
         final String prefix = "testHtml_" + (append ? "append_" : "noAppend_");
-        final Configuration config = LoggerContext.getContext().getConfiguration();
         final RollingFileAppender appender = RollingFileAppender.newBuilder()
                 .setName("RollingHtml")
                 .withFilePattern(DIR + "/" + prefix + "_-%d{MM-dd-yy-HH-mm}-%i.html")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
@@ -37,24 +37,27 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.IOUtils;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for LOG4J2-2760
  */
-@LoggerContextSource(timeout = 10)
 public class RollingAppenderDirectWriteWithHtmlLayoutTest {
 
     private static final String DIR = "target/rolling-direct-htmlLayout";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            null,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Configuration config;
 
@@ -64,11 +67,13 @@ public class RollingAppenderDirectWriteWithHtmlLayoutTest {
     }
 
     @Test
+    @Timeout(10)
     public void testRollingFileAppenderWithHtmlLayout() throws Exception {
         checkAppenderWithHtmlLayout(true);
     }
 
     @Test
+    @Timeout(10)
     public void testRollingFileAppenderWithHtmlLayoutNoAppend() throws Exception {
         checkAppenderWithHtmlLayout(false);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
@@ -18,12 +18,12 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -31,17 +31,16 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.IOUtils;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for LOG4J2-2760
@@ -50,24 +49,21 @@ public class RollingAppenderDirectWriteWithHtmlLayoutTest {
 
     private static final String DIR = "target/rolling-direct-htmlLayout";
 
-    public static LoggerContextRule loggerContextRule = new LoggerContextRule();
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
-
     @Test
+    @LoggerContextSource(DIR)
     public void testRollingFileAppenderWithHtmlLayout() throws Exception {
         checkAppenderWithHtmlLayout(true);
     }
 
     @Test
+    @LoggerContextSource(DIR)
     public void testRollingFileAppenderWithHtmlLayoutNoAppend() throws Exception {
         checkAppenderWithHtmlLayout(false);
     }
 
     private void checkAppenderWithHtmlLayout(final boolean append) throws InterruptedException, IOException {
         final String prefix = "testHtml_" + (append ? "append_" : "noAppend_");
-        final Configuration config = loggerContextRule.getConfiguration();
+        final Configuration config = LoggerContext.getContext().getConfiguration();
         final RollingFileAppender appender = RollingFileAppender.newBuilder()
                 .setName("RollingHtml")
                 .withFilePattern(DIR + "/" + prefix + "_-%d{MM-dd-yy-HH-mm}-%i.html")
@@ -91,7 +87,7 @@ public class RollingAppenderDirectWriteWithHtmlLayoutTest {
             stopped = true;
             Thread.sleep(50);
             final File dir = new File(DIR);
-            assertTrue("Directory not created", dir.exists());
+            assertTrue(dir.exists(), "Directory not created");
             final File[] files = dir.listFiles();
             assertNotNull(files);
             assertThat(files, hasItemInArray(that(hasName(that(endsWith(".html"))))));
@@ -113,7 +109,7 @@ public class RollingAppenderDirectWriteWithHtmlLayoutTest {
                     }
                 }
             }
-            assertEquals("Incorrect number of events read.", count, foundEvents);
+            assertEquals(count, foundEvents, "Incorrect number of events read.");
         } finally {
             if (!stopped) {
                 appender.stop();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.message.SimpleMessage;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -67,13 +66,11 @@ public class RollingAppenderDirectWriteWithHtmlLayoutTest {
     }
 
     @Test
-    @Timeout(10)
     public void testRollingFileAppenderWithHtmlLayout() throws Exception {
         checkAppenderWithHtmlLayout(true);
     }
 
     @Test
-    @Timeout(10)
     public void testRollingFileAppenderWithHtmlLayoutNoAppend() throws Exception {
         checkAppenderWithHtmlLayout(false);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
@@ -28,15 +28,14 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling-direct-reconfigure.xml", timeout = 10)
 public class RollingAppenderDirectWriteWithReconfigureTest {
 
     private static final String CONFIG = "log4j-rolling-direct-reconfigure.xml";
@@ -46,7 +45,11 @@ public class RollingAppenderDirectWriteWithReconfigureTest {
     private static final int MAX_TRIES = 10;
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
@@ -56,6 +59,7 @@ public class RollingAppenderDirectWriteWithReconfigureTest {
     }
 
     @Test
+    @Timeout(10)
     public void testRollingFileAppenderWithReconfigure(final LoggerContext context) throws Exception {
         logger.debug("Before reconfigure");
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
@@ -26,13 +26,17 @@ import java.io.File;
 import java.net.URI;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling-direct-reconfigure.xml", timeout = 10)
 public class RollingAppenderDirectWriteWithReconfigureTest {
 
     private static final String CONFIG = "log4j-rolling-direct-reconfigure.xml";
@@ -41,21 +45,22 @@ public class RollingAppenderDirectWriteWithReconfigureTest {
 
     private static final int MAX_TRIES = 10;
 
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+
     private Logger logger;
 
     @BeforeEach
-    @LoggerContextSource(value = CONFIG, timeout = 10)
-    public void setUp(LoggerContext context) throws Exception {
-        this.logger = context.getLogger(RollingAppenderDirectWriteWithReconfigureTest.class.getName());
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
+        this.logger = loggerContextRule.getLogger(RollingAppenderDirectWriteWithReconfigureTest.class.getName());
     }
 
     @Test
-    @LoggerContextSource(value = CONFIG, timeout = 10)
-    public void testRollingFileAppenderWithReconfigure(LoggerContext context) throws Exception {
+    public void testRollingFileAppenderWithReconfigure(final LoggerContext context) throws Exception {
         logger.debug("Before reconfigure");
 
         @SuppressWarnings("resource") // managed by the rule.
-        final LoggerContext config = context.getConfiguration().getLoggerContext();
+        final Configuration config = context.getConfiguration();
         context.setConfigLocation(new URI(CONFIG));
         context.reconfigure();
         logger.debug("Force a rollover");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithReconfigureTest.java
@@ -16,22 +16,19 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URI;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -44,26 +41,21 @@ public class RollingAppenderDirectWriteWithReconfigureTest {
 
     private static final int MAX_TRIES = 10;
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
-
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
-        this.logger = loggerContextRule.getLogger(RollingAppenderDirectWriteWithReconfigureTest.class.getName());
+    @BeforeEach
+    @LoggerContextSource(value = CONFIG, timeout = 10)
+    public void setUp(LoggerContext context) throws Exception {
+        this.logger = context.getLogger(RollingAppenderDirectWriteWithReconfigureTest.class.getName());
     }
 
     @Test
-    public void testRollingFileAppenderWithReconfigure() throws Exception {
+    @LoggerContextSource(value = CONFIG, timeout = 10)
+    public void testRollingFileAppenderWithReconfigure(LoggerContext context) throws Exception {
         logger.debug("Before reconfigure");
 
         @SuppressWarnings("resource") // managed by the rule.
-        final LoggerContext context = loggerContextRule.getLoggerContext();
-        final Configuration config = context.getConfiguration();
+        final LoggerContext config = context.getConfiguration().getLoggerContext();
         context.setConfigLocation(new URI(CONFIG));
         context.reconfigure();
         logger.debug("Force a rollover");
@@ -75,7 +67,7 @@ public class RollingAppenderDirectWriteWithReconfigureTest {
             }
         }
 
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         assertThat(dir.listFiles().length, is(equalTo(2)));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartup2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartup2Test.java
@@ -16,8 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -33,10 +34,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -50,8 +50,8 @@ public class RollingAppenderOnStartup2Test {
     private static final String ROLLED_FILE_SUFFIX = "-1.log.gz";
     private static final String TEST_DATA = "Hello world!";
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         if (Files.exists(Paths.get("target/rollOnStartup"))) {
             try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
                 for (final Path path : directoryStream) {
@@ -64,7 +64,7 @@ public class RollingAppenderOnStartup2Test {
         // System.setProperty("log4j2.StatusLogger.level", "trace");
         final Configuration configuration = new DefaultConfiguration();
         final Path target = Paths.get(TARGET_FILE);
-        Assert.assertFalse(Files.exists(target));
+        assertFalse(Files.exists(target));
         target.toFile().getParentFile().mkdirs();
         final long timeStamp = System.currentTimeMillis() - (1000 * 60 * 60 * 24);
         final String expectedDate = formatter.format(timeStamp);
@@ -83,8 +83,8 @@ public class RollingAppenderOnStartup2Test {
         System.setProperty("log4j.configurationFile", "log4j-rollOnStartup.json");
     }
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @AfterAll
+    public static void afterAll() throws Exception {
         final long size = 0;
         /* try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
             for (final Path path : directoryStream) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupDirectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupDirectTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.DirectoryStream;
@@ -35,9 +35,9 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -54,8 +54,8 @@ public class RollingAppenderOnStartupDirectTest {
 
     private static LoggerContext loggerContext;
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         if (Files.exists(Paths.get("target/onStartup"))) {
             try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
                 for (final Path path : directoryStream) {
@@ -85,18 +85,19 @@ public class RollingAppenderOnStartupDirectTest {
                 ++fileCount;
                 if (path.toFile().getName().startsWith(ROLLED)) {
                     final List<String> lines = Files.readAllLines(path);
-                    assertTrue("No messages in " + path.toFile().getName(), lines.size() > 0);
                     assertTrue(
-                            "Missing message for " + path.toFile().getName(),
-                            lines.get(0).startsWith(PREFIX));
+                            lines.size() > 0, "No messages in " + path.toFile().getName());
+                    assertTrue(
+                            lines.get(0).startsWith(PREFIX),
+                            "Missing message for " + path.toFile().getName());
                 }
             }
         }
-        assertEquals("File did not roll", 2, fileCount);
+        assertEquals(2, fileCount, "File did not roll");
     }
 
-    @AfterClass
-    public static void afterClass() throws Exception {
+    @AfterAll
+    public static void afterAll() throws Exception {
         Configurator.shutdown(loggerContext);
         try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(DIR))) {
             for (final Path path : directoryStream) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderOnStartupTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.DirectoryStream;
@@ -81,13 +81,14 @@ public class RollingAppenderOnStartupTest {
                 if (path.toFile().getName().startsWith(ROLLED)) {
                     rolled = true;
                     final List<String> lines = Files.readAllLines(path);
-                    assertTrue("No messages in " + path.toFile().getName(), lines.size() > 0);
                     assertTrue(
-                            "Missing message for " + path.toFile().getName(),
-                            lines.get(0).startsWith(PREFIX + "1"));
+                            lines.size() > 0, "No messages in " + path.toFile().getName());
+                    assertTrue(
+                            lines.get(0).startsWith(PREFIX + "1"),
+                            "Missing message for " + path.toFile().getName());
                 }
             }
         }
-        assertTrue("File did not roll", rolled);
+        assertTrue(rolled, "File did not roll");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderRestartTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderRestartTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static junit.framework.Assert.fail;
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,14 +39,14 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.hamcrest.Matcher;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RollingAppenderRestartTest {
 
@@ -56,14 +56,17 @@ public class RollingAppenderRestartTest {
     private static final Path DIR = Paths.get("target/rolling-restart");
     private static final Path FILE = DIR.resolve("test.log");
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR.toAbsolutePath().toString(),
+            CONFIG,
+            RollingAppenderRestartTest.class.getName(),
+            this.getClass().getClassLoader(),
+            false,
+            true,
+            5);
 
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(
-            false, true, 5, DIR.toAbsolutePath().toString());
-
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         tearDown();
         Files.createDirectories(DIR);
@@ -84,7 +87,7 @@ public class RollingAppenderRestartTest {
         assumeTrue(creationTime.equals(newTime) || creationTime.toMillis() == 0L);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws IOException {
         if (Files.exists(DIR)) {
             PathUtils.deleteDirectory(DIR);
@@ -92,15 +95,16 @@ public class RollingAppenderRestartTest {
     }
 
     @Test
-    public void testAppender() throws Exception {
-        final Logger logger = loggerContextRule.getLogger();
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderRestartTest.class.getName());
         logger.info("This is test message number 1");
         // The GZ compression takes place asynchronously.
         // Make sure it's done before validating.
         Thread.yield();
         final String name = "RollingFile";
-        final RollingFileAppender appender = loggerContextRule.getAppender(name);
-        assertNotNull(name, appender);
+        final RollingFileAppender appender =
+                loggerContextRule.getConfiguration().getAppender(name);
+        assertNotNull(appender, name);
         if (appender.getManager().getSemaphore().tryAcquire(5, TimeUnit.SECONDS)) {
             // If we are in here, either the rollover is done or has not taken place yet.
             validate();
@@ -114,7 +118,7 @@ public class RollingAppenderRestartTest {
         final File[] files = DIR.toFile().listFiles();
         Arrays.sort(files);
         assertTrue(
-                "was expecting files with '.gz' suffix, found: " + Arrays.toString(files),
-                hasGzippedFile.matches(files));
+                hasGzippedFile.matches(files),
+                "was expecting files with '.gz' suffix, found: " + Arrays.toString(files));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeCompressPermissionsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeCompressPermissionsTest.java
@@ -16,23 +16,23 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.apache.logging.log4j.core.util.FileUtils;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-1699.
@@ -43,26 +43,27 @@ public class RollingAppenderSizeCompressPermissionsTest {
 
     private static final String DIR = "target/rollingpermissions1";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderSizeCompressPermissionsTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @BeforeClass
-    public static void beforeClass() {
-        Assume.assumeTrue(FileUtils.isFilePosixAttributeViewSupported());
+    @BeforeAll
+    public static void beforeAll() {
+        Assumptions.assumeTrue(FileUtils.isFilePosixAttributeViewSupported());
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderSizeCompressPermissionsTest.class.getName());
     }
 
     @Test
-    public void testAppenderCompressPermissions() throws Exception {
+    public void testAppenderCompressPermissions(final LoggerContext loggerContextRule) throws Exception {
         for (int i = 0; i < 500; ++i) {
             final String message = "This is test message number " + i;
             logger.debug(message);
@@ -70,11 +71,11 @@ public class RollingAppenderSizeCompressPermissionsTest {
                 Thread.sleep(500);
             }
         }
-        if (!loggerContextRule.getLoggerContext().stop(30, TimeUnit.SECONDS)) {
+        if (!loggerContextRule.stop(30, TimeUnit.SECONDS)) {
             System.err.println("Could not stop cleanly " + loggerContextRule + " for " + this);
         }
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists());
+        assertTrue(dir.exists(), "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         int gzippedFiles1 = 0;
@@ -97,8 +98,8 @@ public class RollingAppenderSizeCompressPermissionsTest {
                 assertEquals("rwx------", PosixFilePermissions.toString(Files.getPosixFilePermissions(file.toPath())));
             }
         }
-        assertTrue("Files not rolled : " + files.length, files.length > 2);
-        assertTrue("Files 1 gzipped not rolled : " + gzippedFiles1, gzippedFiles1 > 0);
-        assertTrue("Files 2 gzipped not rolled : " + gzippedFiles2, gzippedFiles2 > 0);
+        assertTrue(files.length > 2, "Files not rolled : " + files.length);
+        assertTrue(gzippedFiles1 > 0, "Files 1 gzipped not rolled : " + gzippedFiles1);
+        assertTrue(gzippedFiles2 > 0, "Files 2 gzipped not rolled : " + gzippedFiles2);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeWithTimeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeWithTimeTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -29,11 +29,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * LOG4J2-2602.
@@ -44,21 +44,22 @@ public class RollingAppenderSizeWithTimeTest {
 
     private static final String DIR = "target/rolling-size-test";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderSizeWithTimeTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderSizeWithTimeTest.class.getName());
     }
 
     @Test
-    public void testAppender() throws Exception {
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final List<String> messages = new ArrayList<>();
         for (int i = 0; i < 5000; ++i) {
             final String message = "This is test message number " + i;
@@ -68,11 +69,11 @@ public class RollingAppenderSizeWithTimeTest {
                 Thread.sleep(10);
             }
         }
-        if (!loggerContextRule.getLoggerContext().stop(30, TimeUnit.SECONDS)) {
+        if (!loggerContextRule.stop(30, TimeUnit.SECONDS)) {
             System.err.println("Could not stop cleanly " + loggerContextRule + " for " + this);
         }
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists());
+        assertTrue(dir.exists(), "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         for (final File file : files) {
@@ -91,7 +92,7 @@ public class RollingAppenderSizeWithTimeTest {
                 messages.remove(line);
             }
         }
-        assertTrue("Log messages lost : " + messages.size(), messages.isEmpty());
-        assertTrue("Files not rolled : " + files.length, files.length > 2);
+        assertTrue(messages.isEmpty(), "Log messages lost : " + messages.size());
+        assertTrue(files.length > 2, "Files not rolled : " + files.length);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeAndSizeDirectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeAndSizeDirectTest.java
@@ -18,19 +18,19 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -41,16 +41,17 @@ public class RollingAppenderTimeAndSizeDirectTest {
 
     private static final String DIR = "target/rolling3Direct";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderTimeAndSizeDirectTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderTimeAndSizeDirectTest.class.getName());
     }
 
@@ -62,7 +63,7 @@ public class RollingAppenderTimeAndSizeDirectTest {
         }
         Thread.sleep(50);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         assertThat(files, hasItemInArray(that(hasName(that(endsWith(".gz"))))));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeAndSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeAndSizeTest.java
@@ -18,13 +18,13 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -32,11 +32,11 @@ import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.Random;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -47,16 +47,17 @@ public class RollingAppenderTimeAndSizeTest {
 
     private static final String DIR = "target/rolling3/test";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderTimeAndSizeTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingAppenderTimeAndSizeTest.class.getName());
     }
 
@@ -64,7 +65,7 @@ public class RollingAppenderTimeAndSizeTest {
     public void testAppender() throws Exception {
         final Random rand = new Random();
         final File logFile = new File("target/rolling3/rollingtest.log");
-        assertTrue("target/rolling3/rollingtest.log does not exist", logFile.exists());
+        assertTrue(logFile.exists(), "target/rolling3/rollingtest.log does not exist");
         final FileTime time = (FileTime) Files.getAttribute(logFile.toPath(), "creationTime");
         for (int j = 0; j < 100; ++j) {
             final int count = rand.nextInt(50);
@@ -75,7 +76,7 @@ public class RollingAppenderTimeAndSizeTest {
         }
         Thread.sleep(50);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         Arrays.sort(files);
         assertNotNull(files);
@@ -94,11 +95,11 @@ public class RollingAppenderTimeAndSizeTest {
             fileCounter = previous.equals(fileParts[1]) ? ++fileCounter : 1;
             previous = fileParts[1];
             assertEquals(
-                    "Incorrect file name. Expected counter value of " + fileCounter + " in " + actual,
                     Integer.toString(fileCounter),
-                    fileParts[2]);
+                    fileParts[2],
+                    "Incorrect file name. Expected counter value of " + fileCounter + " in " + actual);
         }
         final FileTime endTime = (FileTime) Files.getAttribute(logFile.toPath(), "creationTime");
-        assertNotEquals("Creation times are equal", time, endTime);
+        assertNotEquals(time, endTime, "Creation times are equal");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -48,7 +47,6 @@ public class RollingAppenderTimeTest {
             this.getClass().getClassLoader());
 
     @Test
-    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Logger logger = loggerContextRule.getLogger(RollingAppenderTimeTest.class.getName());
         logger.debug("This is test message number 1");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
@@ -20,34 +20,32 @@ import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
+@LoggerContextSource(value = "log4j-rolling2.xml", timeout = 10)
 public class RollingAppenderTimeTest {
 
-    private static final String CONFIG = "log4j-rolling2.xml";
     private static final String DIR = "target/rolling2";
 
-    private final LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
 
     @Test
-    public void testAppender() throws Exception {
-        final Logger logger = loggerContextRule.getLogger();
+    public void testAppender(final LoggerContext loggerContextRule) throws Exception {
+        final Logger logger = loggerContextRule.getLogger(RollingAppenderTimeTest.class.getName());
         logger.debug("This is test message number 1");
         Thread.sleep(1500);
         // Trigger the rollover
@@ -55,7 +53,7 @@ public class RollingAppenderTimeTest {
             logger.debug("This is test message number " + i + 1);
         }
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
 
         final int MAX_TRIES = 20;
         final Matcher<File[]> hasGzippedFile = hasItemInArray(that(hasName(that(endsWith(".gz")))));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTimeTest.java
@@ -27,23 +27,28 @@ import java.io.File;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
  */
-@LoggerContextSource(value = "log4j-rolling2.xml", timeout = 10)
 public class RollingAppenderTimeTest {
 
+    private static final String CONFIG = "log4j-rolling2.xml";
     private static final String DIR = "target/rolling2";
 
     @RegisterExtension
-    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(DIR);
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingAppenderDeleteScriptTest.class.getName(),
+            this.getClass().getClassLoader());
 
     @Test
+    @Timeout(10)
     public void testAppender(final LoggerContext loggerContextRule) throws Exception {
         final Logger logger = loggerContextRule.getLogger(RollingAppenderTimeTest.class.getName());
         logger.debug("This is test message number 1");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderUncompressedTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderUncompressedTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.LogManager;
@@ -26,10 +26,9 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.CleanFolders;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -41,20 +40,19 @@ public class RollingAppenderUncompressedTest {
 
     private final Logger logger = LogManager.getLogger(RollingAppenderUncompressedTest.class.getName());
 
-    @ClassRule
-    public static CleanFolders rule = new CleanFolders(CONFIG);
-
-    @BeforeClass
-    public static void setupClass() {
+    @BeforeAll
+    public static void setupAll() {
+        new CleanFolders(CONFIG);
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
     }
 
-    @AfterClass
-    public static void cleanupClass() {
+    @AfterAll
+    public static void cleanupAll() {
         System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
         final LoggerContext ctx = LoggerContext.getContext();
         ctx.reconfigure();
         StatusLogger.getLogger().reset();
+        new CleanFolders(CONFIG);
     }
 
     @Test
@@ -63,7 +61,7 @@ public class RollingAppenderUncompressedTest {
             logger.debug("This is test message number " + i);
         }
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         boolean found = false;
@@ -74,6 +72,6 @@ public class RollingAppenderUncompressedTest {
                 break;
             }
         }
-        assertTrue("No archived files found", found);
+        assertTrue(found, "No archived files found");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectSizeTimeNewDirectoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectSizeTimeNewDirectoryTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Collections;
@@ -25,11 +25,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * This test attempts to validate that logging rolls when the file size exceeds 5KB or every second.
@@ -43,17 +43,18 @@ public class RollingDirectSizeTimeNewDirectoryTest implements RolloverListener {
     // Note that the path is hardcoded in the configuration!
     private static final String DIR = "target/rolling-size-time-new-directory";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingDirectSizeTimeNewDirectoryTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private final Map<String, AtomicInteger> rolloverFiles = new HashMap<>();
 
     @Test
-    public void streamClosedError() throws Exception {
-        ((RollingFileAppender) loggerContextRule.getAppender("RollingFile"))
+    public void streamClosedError(final LoggerContext loggerContextRule) throws Exception {
+        ((RollingFileAppender) loggerContextRule.getConfiguration().getAppender("RollingFile"))
                 .getManager()
                 .addRolloverListener(this);
         final Logger logger = loggerContextRule.getLogger(RollingDirectSizeTimeNewDirectoryTest.class);
@@ -66,10 +67,10 @@ public class RollingDirectSizeTimeNewDirectoryTest implements RolloverListener {
             logger.info("nHq6p9kgfvWfjzDRYbZp");
         }
 
-        assertTrue("A time based rollover did not occur", rolloverFiles.size() > 1);
+        assertTrue(rolloverFiles.size() > 1, "A time based rollover did not occur");
         final int maxFiles = Collections.max(rolloverFiles.values(), Comparator.comparing(AtomicInteger::get))
                 .get();
-        assertTrue("No size based rollovers occurred", maxFiles > 1);
+        assertTrue(maxFiles > 1, "No size based rollovers occurred");
     }
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectTimeNewDirectoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectTimeNewDirectoryTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -25,10 +25,10 @@ import java.util.Iterator;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class RollingDirectTimeNewDirectoryTest {
 
@@ -37,11 +37,12 @@ public class RollingDirectTimeNewDirectoryTest {
     // Note that the path is hardcoded in the configuration!
     private static final String DIR = "target/rolling-folder-direct";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingDirectTimeNewDirectoryTest.class.getName(),
+            this.getClass().getClassLoader());
 
     /**
      * This test logs directly to the target file. Rollover is set to happen once per second. We pause once
@@ -50,7 +51,7 @@ public class RollingDirectTimeNewDirectoryTest {
      * @throws Exception
      */
     @Test
-    public void streamClosedError() throws Exception {
+    public void streamClosedError(final LoggerContext loggerContextRule) throws Exception {
 
         final Logger logger = loggerContextRule.getLogger(RollingDirectTimeNewDirectoryTest.class.getName());
 
@@ -71,17 +72,18 @@ public class RollingDirectTimeNewDirectoryTest {
 
             final int minExpectedLogFolderCount = 2;
             assertTrue(
-                    "was expecting at least " + minExpectedLogFolderCount + " folders, " + "found " + logFolders.length,
-                    logFolders.length >= minExpectedLogFolderCount);
+                    logFolders.length >= minExpectedLogFolderCount,
+                    "was expecting at least " + minExpectedLogFolderCount + " folders, " + "found "
+                            + logFolders.length);
 
             for (File logFolder : logFolders) {
                 final File[] logFiles = logFolder.listFiles();
                 if (logFiles != null) {
-                    assertTrue("Only 1 file per folder expected: got " + logFiles.length, logFiles.length <= 1);
+                    assertTrue(logFiles.length <= 1, "Only 1 file per folder expected: got " + logFiles.length);
                     totalFiles += logFiles.length;
                 }
             }
-            assertTrue("Expected at least 2 files", totalFiles >= 2);
+            assertTrue(totalFiles >= 2, "Expected at least 2 files");
 
         } catch (AssertionError error) {
             System.out.format("log directory (%s) contents:%n", DIR);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderAccessTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderAccessTest.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderAccessTest {
 
@@ -49,8 +49,8 @@ public class RollingFileAppenderAccessTest {
             final RollingFileManager manager = appender.getManager();
             // Since the RolloverStrategy and TriggeringPolicy are immutable, we could also use generics to type their
             // access.
-            Assert.assertNotNull(manager.getRolloverStrategy());
-            Assert.assertNotNull(manager.getTriggeringPolicy());
+            Assertions.assertNotNull(manager.getRolloverStrategy());
+            Assertions.assertNotNull(manager.getTriggeringPolicy());
         }
     }
 
@@ -84,8 +84,8 @@ public class RollingFileAppenderAccessTest {
             final RollingFileManager manager = appender.getManager();
             // Since the RolloverStrategy and TriggeringPolicy are immutable, we could also use generics to type their
             // access.
-            Assert.assertNotNull(manager.getRolloverStrategy());
-            Assert.assertNotNull(manager.getTriggeringPolicy());
+            Assertions.assertNotNull(manager.getRolloverStrategy());
+            Assertions.assertNotNull(manager.getTriggeringPolicy());
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderBuilderTest.java
@@ -17,8 +17,8 @@
 package org.apache.logging.log4j.core.appender.rolling;
 
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderBuilderTest {
 
@@ -27,6 +27,6 @@ public class RollingFileAppenderBuilderTest {
      */
     @Test
     public void testDefaultImmediateFlush() {
-        Assert.assertTrue(RollingFileAppender.newBuilder().isImmediateFlush());
+        Assertions.assertTrue(RollingFileAppender.newBuilder().isImmediateFlush());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderInterruptedThreadTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderInterruptedThreadTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.Level;
@@ -30,11 +32,9 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.junit.CleanFolders;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/LOG4J2-1798
@@ -44,13 +44,11 @@ public class RollingFileAppenderInterruptedThreadTest {
     private static final String ROLLING_APPENDER_FILES_DIR =
             "target/" + RollingFileAppenderInterruptedThreadTest.class.getSimpleName();
 
-    @Rule
-    public CleanFolders cleanFolders = new CleanFolders(true, false, 3, ROLLING_APPENDER_FILES_DIR);
-
     LoggerContext loggerContext;
 
-    @Before
+    @BeforeEach
     public void setUp() {
+        new CleanFolders(true, false, 3, ROLLING_APPENDER_FILES_DIR);
         final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setConfigurationName("LOG4J2-1798 test");
 
@@ -70,24 +68,25 @@ public class RollingFileAppenderInterruptedThreadTest {
         loggerContext = Configurator.initialize(builder.build());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Configurator.shutdown(loggerContext);
         loggerContext = null;
+        new CleanFolders(true, false, 3, ROLLING_APPENDER_FILES_DIR);
     }
 
     @Test
     public void testRolloverInInterruptedThread() {
         final Logger logger = loggerContext.getLogger(getClass().getName());
 
-        Assert.assertThat(logger.getAppenders().values(), hasItem(instanceOf(RollingFileAppender.class)));
+        assertThat(logger.getAppenders().values(), hasItem(instanceOf(RollingFileAppender.class)));
 
         logger.info("Sending logging event 1"); // send first event to initialize rollover system
 
         Thread.currentThread().interrupt(); // mark thread as interrupted
         logger.info("Sending logging event 2"); // send second event to trigger rotation, expecting 2 files in result
 
-        Assert.assertTrue(new File(ROLLING_APPENDER_FILES_DIR, "file-1.log").exists());
-        Assert.assertTrue(new File(ROLLING_APPENDER_FILES_DIR, "file-2.log").exists());
+        assertTrue(new File(ROLLING_APPENDER_FILES_DIR, "file-1.log").exists());
+        assertTrue(new File(ROLLING_APPENDER_FILES_DIR, "file-2.log").exists());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderLayoutTest.java
@@ -18,15 +18,15 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RollingFileAppenderLayoutTest {
 
     @Test
     public void testDefaultLayout() throws Exception {
         // @formatter:off
-        Assert.assertNotNull(RollingFileAppender.newBuilder()
+        Assertions.assertNotNull(RollingFileAppender.newBuilder()
                 .setName(RollingFileAppenderLayoutTest.class.getName())
                 .setConfiguration(new DefaultConfiguration())
                 .withFileName("log.txt")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureTest.java
@@ -16,20 +16,18 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/LOG4J2-1967
  */
 public class RollingFileAppenderReconfigureTest {
 
-    @Rule
-    public final LoggerContextRule loggerContextRule = new LoggerContextRule("rolling-file-appender-reconfigure.xml");
-
     @Test
-    public void testReconfigure() {
+    @LoggerContextSource(value = "rolling-file-appender-reconfigure.xml")
+    public void testReconfigure(final LoggerContext loggerContextRule) {
         loggerContextRule.reconfigure();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureUndefinedSystemPropertyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureUndefinedSystemPropertyTest.java
@@ -16,21 +16,18 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests https://issues.apache.org/jira/browse/LOG4J2-1967
  */
 public class RollingFileAppenderReconfigureUndefinedSystemPropertyTest {
 
-    @Rule
-    public final LoggerContextRule loggerContextRule =
-            new LoggerContextRule("src/test/rolling-file-appender-reconfigure.original.xml");
-
     @Test
-    public void testReconfigure() {
+    @LoggerContextSource(value = "src/test/rolling-file-appender-reconfigure.original.xml")
+    public void testReconfigure(final LoggerContext loggerContextRule) {
         loggerContextRule.reconfigure();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderUpdateDataTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderUpdateDataTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -25,9 +29,8 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests LOG4J2-2009 Rolling appender managers broken on pattern/policy reconfiguration
@@ -64,7 +67,7 @@ public class RollingFileAppenderUpdateDataTest {
     private LoggerContext loggerContext1 = null;
     private LoggerContext loggerContext2 = null;
 
-    @After
+    @AfterEach
     public void after() {
         if (loggerContext1 != null) {
             loggerContext1.close();
@@ -99,8 +102,8 @@ public class RollingFileAppenderUpdateDataTest {
 
         // rebuild config with date based rollover
         loggerContext2 = Configurator.initialize(buildConfigB().build());
-        Assert.assertNotNull("No LoggerContext", loggerContext2);
-        Assert.assertTrue("Expected same logger context to be returned", loggerContext1 == loggerContext2);
+        assertNotNull(loggerContext2, "No LoggerContext");
+        assertTrue(loggerContext1 == loggerContext2, "Expected same logger context to be returned");
         validateAppender(loggerContext1, "target/rolling-update-date/foo.log.%i");
     }
 
@@ -117,8 +120,8 @@ public class RollingFileAppenderUpdateDataTest {
 
     private void validateAppender(final LoggerContext loggerContext, final String expectedFilePattern) {
         final RollingFileAppender appender = loggerContext.getConfiguration().getAppender("fooAppender");
-        Assert.assertNotNull(appender);
-        Assert.assertEquals(expectedFilePattern, appender.getFilePattern());
+        assertNotNull(appender);
+        assertEquals(expectedFilePattern, appender.getFilePattern());
         LogManager.getLogger("root").info("just to show it works.");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManagerTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.Issue;
 
 public class RollingFileManagerTest {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingNewDirectoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingNewDirectoryTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests
@@ -35,16 +35,17 @@ public class RollingNewDirectoryTest {
 
     private static final String DIR = "target/rolling-new-directory";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingNewDirectoryTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingNewDirectoryTest.class.getName());
     }
 
@@ -55,7 +56,7 @@ public class RollingNewDirectoryTest {
             Thread.sleep(300);
         }
         final File dir = new File(DIR);
-        assertNotNull("No directory created", dir);
-        assertTrue("Child irectories not created", dir.exists() && dir.listFiles().length > 2);
+        assertNotNull(dir, "No directory created");
+        assertTrue(dir.exists() && dir.listFiles().length > 2, "Child irectories not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
@@ -20,13 +20,13 @@ import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.beforeNow
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasLength;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.isEmpty;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.lastModified;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -45,7 +45,7 @@ import org.apache.logging.log4j.core.util.Closer;
 import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.NullOutputStream;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the RollingRandomAccessFileManager class.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteTest.java
@@ -18,19 +18,19 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -41,16 +41,17 @@ public class RollingRandomAppenderDirectWriteTest {
 
     private static final String DIR = "target/rolling-random-direct";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingRandomAppenderDirectWriteTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingRandomAppenderDirectWriteTest.class.getName());
     }
 
@@ -61,7 +62,7 @@ public class RollingRandomAppenderDirectWriteTest {
         }
         Thread.sleep(50);
         final File dir = new File(DIR);
-        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        assertTrue(dir.exists() && dir.listFiles().length > 0, "Directory not created");
         final File[] files = dir.listFiles();
         assertNotNull(files);
         assertThat(files, hasItemInArray(that(hasName(that(endsWith(".gz"))))));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteWithFilenameTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteWithFilenameTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFoldersRuleExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  *
@@ -35,22 +35,23 @@ public class RollingRandomAppenderDirectWriteWithFilenameTest {
 
     private static final String DIR = "target/random-1833";
 
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+    @RegisterExtension
+    CleanFoldersRuleExtension extension = new CleanFoldersRuleExtension(
+            DIR,
+            CONFIG,
+            RollingRandomAppenderDirectWriteWithFilenameTest.class.getName(),
+            this.getClass().getClassLoader());
 
     private Logger logger;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(final LoggerContext loggerContextRule) throws Exception {
         this.logger = loggerContextRule.getLogger(RollingRandomAppenderDirectWriteWithFilenameTest.class.getName());
     }
 
     @Test
     public void testAppender() throws Exception {
         final File dir = new File(DIR);
-        assertFalse("Directory created", dir.exists());
+        assertFalse(dir.exists(), "Directory created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverFilePatternTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverFilePatternTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.regex.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test getEligibleFiles method.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/PathConditionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/PathConditionTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rolling.action;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -28,7 +30,6 @@ import org.apache.logging.log4j.core.config.AppenderControl;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,18 +73,18 @@ public class DefaultRouteScriptAppenderTest {
         final RoutingAppender routingAppender = getRoutingAppender();
         final ConcurrentMap<Object, Object> map = routingAppender.getScriptStaticVariables();
         if (expectBindingEntries) {
-            assertEquals("TestValue2", map.get("TestKey"));
-            assertEquals("HEXDUMP", map.get("MarkerName"));
+            assertEquals(map.get("TestKey"), "TestValue2");
+            assertEquals(map.get("MarkerName"), "HEXDUMP");
         }
     }
 
     private ListAppender getListAppender() {
         final String key = "Service2";
         final RoutingAppender routingAppender = getRoutingAppender();
-        Assert.assertTrue(routingAppender.isStarted());
+        assertTrue(routingAppender.isStarted());
         final Map<String, AppenderControl> appenders = routingAppender.getAppenders();
         final AppenderControl appenderControl = appenders.get(key);
-        assertNotNull("No appender control generated for '" + key + "'; appenders = " + appenders, appenderControl);
+        assertNotNull(appenderControl, "No appender control generated for '" + key + "'; appenders = " + appenders);
         final ListAppender listAppender = (ListAppender) appenderControl.getAppender();
         return listAppender;
     }
@@ -97,11 +98,11 @@ public class DefaultRouteScriptAppenderTest {
         final Logger logger = loggerContextRule.getLogger(DefaultRouteScriptAppenderTest.class);
         logger.error("Hello");
         final ListAppender listAppender = getListAppender();
-        assertEquals("Incorrect number of events", 1, listAppender.getEvents().size());
+        assertEquals(1, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error("World");
-        assertEquals("Incorrect number of events", 2, listAppender.getEvents().size());
+        assertEquals(2, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error(marker, "DEADBEEF");
-        assertEquals("Incorrect number of events", 3, listAppender.getEvents().size());
+        assertEquals(3, listAppender.getEvents().size(), "Incorrect number of events");
     }
 
     @Test(expected = AssertionError.class)
@@ -112,29 +113,27 @@ public class DefaultRouteScriptAppenderTest {
     @Test
     public void testListAppenderPresence() {
         // No appender until an event is routed, even thought we initialized the default route on startup.
-        Assert.assertNull(
-                "No appender control generated",
-                getRoutingAppender().getAppenders().get("Service2"));
+        assertNull(getRoutingAppender().getAppenders().get("Service2"), "No appender control generated");
     }
 
     @Test
     public void testNoPurgePolicy() {
         // No PurgePolicy in this test
-        Assert.assertNull("Unexpected PurgePolicy", getRoutingAppender().getPurgePolicy());
+        assertNull(getRoutingAppender().getPurgePolicy(), "Unexpected PurgePolicy");
     }
 
     @Test
     public void testNoRewritePolicy() {
         // No RewritePolicy in this test
-        Assert.assertNull("Unexpected RewritePolicy", getRoutingAppender().getRewritePolicy());
+        assertNull(getRoutingAppender().getRewritePolicy(), "Unexpected RewritePolicy");
     }
 
     @Test
     public void testRoutingAppenderDefaultRouteKey() {
         final RoutingAppender routingAppender = getRoutingAppender();
-        Assert.assertNotNull(routingAppender.getDefaultRouteScript());
-        Assert.assertNotNull(routingAppender.getDefaultRoute());
-        assertEquals("Service2", routingAppender.getDefaultRoute().getKey());
+        assertNotNull(routingAppender.getDefaultRouteScript());
+        assertNotNull(routingAppender.getDefaultRoute());
+        assertEquals(routingAppender.getDefaultRoute().getKey(), "Service2");
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppender2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppender2Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -46,11 +46,11 @@ public class JsonRoutingAppender2Test {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Unknown");
         EventLogger.logEvent(msg);
         final File file = new File(LOG_FILENAME);
-        assertTrue("File was not created", file.exists());
+        assertTrue(file.exists(), "File was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppender2Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppender2Test.java
@@ -23,29 +23,32 @@ import java.io.File;
 import java.util.List;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing2.json")
 public class JsonRoutingAppender2Test {
-    private static final String CONFIG = "log4j-routing2.json";
     private static final String LOG_FILENAME = "target/rolling1/rollingtest-Unknown.log";
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILENAME);
+    @BeforeEach
+    public void beforeEach() {
+        new CleanFiles(LOG_FILENAME);
+    }
 
     @Test
-    public void routingTest() {
+    public void routingTest(final LoggerContext loggerContext) {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
-        final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
+        final ListAppender app = loggerContext.getConfiguration().getAppender("List");
+        final List<LogEvent> list = app.getEvents();
         assertNotNull(list, "No events generated");
         assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Unknown");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppenderTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -46,11 +46,11 @@ public class JsonRoutingAppenderTest {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Unknown");
         EventLogger.logEvent(msg);
         final File file = new File(LOG_FILENAME);
-        assertTrue("File was not created", file.exists());
+        assertTrue(file.exists(), "File was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/JsonRoutingAppenderTest.java
@@ -23,29 +23,32 @@ import java.io.File;
 import java.util.List;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing.json")
 public class JsonRoutingAppenderTest {
-    private static final String CONFIG = "log4j-routing.json";
     private static final String LOG_FILENAME = "target/rolling1/rollingtest-Unknown.log";
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILENAME);
+    @BeforeEach
+    public void beforeEach() {
+        new CleanFiles(LOG_FILENAME);
+    }
 
     @Test
-    public void routingTest() {
+    public void routingTest(final LoggerContext loggerContext) {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
-        final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
+        final ListAppender app = loggerContext.getConfiguration().getAppender("List");
+        final List<LogEvent> list = app.getEvents();
         assertNotNull(list, "No events generated");
         assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Unknown");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
@@ -23,40 +23,42 @@ import java.io.File;
 import java.util.List;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing.properties")
 public class PropertiesRoutingAppenderTest {
-    private static final String CONFIG = "log4j-routing.properties";
     private static final String UNKNOWN_LOG_FILE = "target/rolling1/rollingtestProps-Unknown.log";
     private static final String ALERT_LOG_FILE = "target/routing1/routingtestProps-Alert.log";
     private static final String ACTIVITY_LOG_FILE = "target/routing1/routingtestProps-Activity.log";
 
     private ListAppender app;
+    private LoggerContext context = null;
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
-
-    @Before
-    public void setUp() throws Exception {
-        this.app = this.loggerContextRule.getListAppender("List");
+    PropertiesRoutingAppenderTest(LoggerContext context) {
+        this.context = context;
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        new CleanFiles(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
+        this.app = context.getConfiguration().getAppender("List");
+    }
+
+    @AfterEach
+    public void tearDown(@Named("List") final ListAppender appender) throws Exception {
         this.app.clear();
-        this.loggerContextRule.getLoggerContext().stop();
+        this.app.stop();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -64,15 +64,15 @@ public class PropertiesRoutingAppenderTest {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = app.getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Alert");
         EventLogger.logEvent(msg);
         File file = new File(ALERT_LOG_FILE);
-        assertTrue("Alert file was not created", file.exists());
+        assertTrue(file.exists(), "Alert file was not created");
         msg = new StructuredDataMessage("Test", "This is a test", "Activity");
         EventLogger.logEvent(msg);
         file = new File(ACTIVITY_LOG_FILE);
-        assertTrue("Activity file was not created", file.exists());
+        assertTrue(file.exists(), "Activity file was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/PropertiesRoutingAppenderTest.java
@@ -52,13 +52,13 @@ public class PropertiesRoutingAppenderTest {
     @BeforeEach
     public void beforeEach() throws Exception {
         new CleanFiles(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
-        this.app = context.getConfiguration().getAppender("List");
+        this.app = this.context.getConfiguration().getAppender("List");
     }
 
     @AfterEach
     public void tearDown(@Named("List") final ListAppender appender) throws Exception {
         this.app.clear();
-        this.app.stop();
+        this.context.stop();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutesScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutesScriptAppenderTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +35,7 @@ import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.categories.Scripts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.Assert;
+// import org.junit.jupiter.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,18 +78,18 @@ public class RoutesScriptAppenderTest {
         final RoutingAppender routingAppender = getRoutingAppender();
         final ConcurrentMap<Object, Object> map = routingAppender.getScriptStaticVariables();
         if (expectBindingEntries) {
-            assertEquals("TestValue2", map.get("TestKey"));
-            assertEquals("HEXDUMP", map.get("MarkerName"));
+            assertEquals(map.get("TestKey"), "TestValue2");
+            assertEquals(map.get("MarkerName"), "HEXDUMP");
         }
     }
 
     private ListAppender getListAppender() {
         final String key = "Service2";
         final RoutingAppender routingAppender = getRoutingAppender();
-        Assert.assertTrue(routingAppender.isStarted());
+        assertTrue(routingAppender.isStarted());
         final Map<String, AppenderControl> appenders = routingAppender.getAppenders();
         final AppenderControl appenderControl = appenders.get(key);
-        assertNotNull("No appender control generated for '" + key + "'; appenders = " + appenders, appenderControl);
+        assertNotNull(appenderControl, "No appender control generated for '" + key + "'; appenders = " + appenders);
         return (ListAppender) appenderControl.getAppender();
     }
 
@@ -100,11 +102,11 @@ public class RoutesScriptAppenderTest {
         final Logger logger = loggerContextRule.getLogger(RoutesScriptAppenderTest.class);
         logger.error("Hello");
         final ListAppender listAppender = getListAppender();
-        assertEquals("Incorrect number of events", 1, listAppender.getEvents().size());
+        assertEquals(1, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error("World");
-        assertEquals("Incorrect number of events", 2, listAppender.getEvents().size());
+        assertEquals(2, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error(marker, "DEADBEEF");
-        assertEquals("Incorrect number of events", 3, listAppender.getEvents().size());
+        assertEquals(3, listAppender.getEvents().size(), "Incorrect number of events");
     }
 
     @Test(expected = AssertionError.class)
@@ -115,21 +117,19 @@ public class RoutesScriptAppenderTest {
     @Test
     public void testListAppenderPresence() {
         // No appender until an event is routed, even thought we initialized the default route on startup.
-        Assert.assertNull(
-                "No appender control generated",
-                getRoutingAppender().getAppenders().get("Service2"));
+        assertNull(getRoutingAppender().getAppenders().get("Service2"), "No appender control generated");
     }
 
     @Test
     public void testNoPurgePolicy() {
         // No PurgePolicy in this test
-        Assert.assertNull("Unexpected PurgePolicy", getRoutingAppender().getPurgePolicy());
+        assertNull(getRoutingAppender().getPurgePolicy(), "Unexpected PurgePolicy");
     }
 
     @Test
     public void testNoRewritePolicy() {
         // No RewritePolicy in this test
-        Assert.assertNull("Unexpected RewritePolicy", getRoutingAppender().getRewritePolicy());
+        assertNull(getRoutingAppender().getRewritePolicy(), "Unexpected RewritePolicy");
     }
 
     @Test
@@ -138,8 +138,8 @@ public class RoutesScriptAppenderTest {
         assertEquals(expectBindingEntries, routingAppender.getDefaultRouteScript() != null);
         assertEquals(expectBindingEntries, routingAppender.getDefaultRoute() != null);
         final Routes routes = routingAppender.getRoutes();
-        Assert.assertNotNull(routes);
-        Assert.assertNotNull(routes.getPatternScript());
+        assertNotNull(routes);
+        assertNotNull(routes.getPatternScript());
         final LogEvent logEvent =
                 DefaultLogEventFactory.getInstance().createEvent("", null, "", Level.ERROR, null, null, null);
         assertEquals("Service2", routes.getPattern(logEvent, new ConcurrentHashMap<>()));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender2767Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender2767Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -57,9 +57,9 @@ public class RoutingAppender2767Test {
         final StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final File file = new File(ACTIVITY_LOG_FILE);
-        assertTrue("Activity file was not created", file.exists());
+        assertTrue(file.exists(), "Activity file was not created");
         final List<String> lines = Files.lines(file.toPath()).collect(Collectors.toList());
-        assertEquals("Incorrect number of lines", 1, lines.size());
-        assertTrue("Incorrect content", lines.get(0).contains("This is a test"));
+        assertEquals(1, lines.size(), "Incorrect number of lines");
+        assertTrue(lines.get(0).contains("This is a test"), "Incorrect content");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender2767Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender2767Test.java
@@ -24,32 +24,37 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.EventLogger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+// import org.junit.Rule;
+// import org.junit.rules.RuleChain;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing-2767.xml")
 public class RoutingAppender2767Test {
-    private static final String CONFIG = "log4j-routing-2767.xml";
     private static final String ACTIVITY_LOG_FILE = "target/routing1/routingtest-Service.log";
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
+    private LoggerContext context = null;
 
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(ACTIVITY_LOG_FILE);
+    RoutingAppender2767Test(LoggerContext context) {
+        this.context = context;
+    }
 
-    @Before
-    public void setUp() throws Exception {}
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        new CleanFiles(ACTIVITY_LOG_FILE);
+    }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
-        this.loggerContextRule.getLoggerContext().stop();
+        this.context.stop();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
@@ -26,32 +26,39 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StringMapMessage;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+@LoggerContextSource("log4j-routing3350.xml")
 public class RoutingAppender3350Test {
-    private static final String CONFIG = "log4j-routing3350.xml";
     private static final String LOG_FILE = "target/tmp/test.log";
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
+    private LoggerContext context = null;
 
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILE);
+    RoutingAppender3350Test(LoggerContext context) {
+        this.context = context;
+    }
 
-    @After
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        new CleanFiles(LOG_FILE);
+    }
+
+    @AfterEach
     public void tearDown() throws Exception {
-        this.loggerContextRule.getLoggerContext().stop();
+        this.context.stop();
     }
 
     @Test
-    public void routingTest() throws IOException {
+    public void routingTest(final LoggerContext loggerContext) throws IOException {
         final String expected = "expectedValue";
         final StringMapMessage message = new StringMapMessage().with("data", expected);
-        final Logger logger = loggerContextRule.getLoggerContext().getLogger(getClass());
+        final Logger logger = loggerContext.getLogger(getClass());
         logger.error(message);
         final File file = new File(LOG_FILE);
         try (final InputStream inputStream = new FileInputStream(file);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderKeyLookupEvaluationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderKeyLookupEvaluationTest.java
@@ -19,56 +19,51 @@ package org.apache.logging.log4j.core.appender.routing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RoutingAppenderKeyLookupEvaluationTest {
-    private static final String CONFIG = "log4j-routing-lookup.xml";
-
     private static final String KEY = "user";
-    private ListAppender app;
 
-    @Rule
-    public final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ThreadContext.remove(KEY);
-        this.app = this.loggerContextRule.getListAppender("List");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        this.app.clear();
-        this.loggerContextRule.getLoggerContext().stop();
+    @AfterEach
+    public void tearDown(@Named("List") final ListAppender app, final LoggerContext loggerContext) throws Exception {
         ThreadContext.remove(KEY);
     }
 
     @Test
-    public void testRoutingNoUser() {
-        final Logger logger = loggerContextRule.getLogger(getClass());
+    @LoggerContextSource("log4j-routing-lookup.xml")
+    public void testRoutingNoUser(final LoggerContext loggerContext, @Named("List") final ListAppender app) {
+        final Logger logger = loggerContext.getLogger(getClass());
         logger.warn("no user");
         final String message = app.getMessages().get(0);
         assertEquals("WARN ${ctx:user} no user", message);
     }
 
     @Test
-    public void testRoutingDoesNotMatchRoute() {
-        final Logger logger = loggerContextRule.getLogger(getClass());
+    @LoggerContextSource("log4j-routing-lookup.xml")
+    public void testRoutingDoesNotMatchRoute(final LoggerContext loggerContext, @Named("List") final ListAppender app) {
+        final Logger logger = loggerContext.getLogger(getClass());
         ThreadContext.put(KEY, "noRouteExists");
         logger.warn("unmatched user");
         assertTrue(app.getMessages().isEmpty());
     }
 
     @Test
-    public void testRoutingContainsLookup() {
-        final Logger logger = loggerContextRule.getLogger(getClass());
+    @LoggerContextSource("log4j-routing-lookup.xml")
+    public void testRoutingContainsLookup(final LoggerContext loggerContext, @Named("List") final ListAppender app) {
+        final Logger logger = loggerContext.getLogger(getClass());
         ThreadContext.put(KEY, "${java:version}");
         logger.warn("naughty user");
         final String message = app.getMessages().get(0);
@@ -76,8 +71,10 @@ public class RoutingAppenderKeyLookupEvaluationTest {
     }
 
     @Test
-    public void testRoutingMatchesEscapedLookup() {
-        final Logger logger = loggerContextRule.getLogger(getClass());
+    @LoggerContextSource("log4j-routing-lookup.xml")
+    public void testRoutingMatchesEscapedLookup(
+            final LoggerContext loggerContext, @Named("List") final ListAppender app) {
+        final Logger logger = loggerContext.getLogger(getClass());
         ThreadContext.put(KEY, "${upper:name}");
         logger.warn("naughty user");
         final String message = app.getMessages().get(0);
@@ -85,8 +82,10 @@ public class RoutingAppenderKeyLookupEvaluationTest {
     }
 
     @Test
-    public void testRoutesThemselvesNotEvaluated() {
-        final Logger logger = loggerContextRule.getLogger(getClass());
+    @LoggerContextSource("log4j-routing-lookup.xml")
+    public void testRoutesThemselvesNotEvaluated(
+            final LoggerContext loggerContext, @Named("List") final ListAppender app) {
+        final Logger logger = loggerContext.getLogger(getClass());
         ThreadContext.put(KEY, "NAME");
         logger.warn("unmatched user");
         assertTrue(app.getMessages().isEmpty());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderKeyLookupEvaluationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderKeyLookupEvaluationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.logging.log4j.ThreadContext;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
@@ -23,40 +23,45 @@ import java.io.File;
 import java.util.List;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing.xml")
 public class RoutingAppenderTest {
-    private static final String CONFIG = "log4j-routing.xml";
     private static final String UNKNOWN_LOG_FILE = "target/rolling1/rollingtest-Unknown.log";
     private static final String ALERT_LOG_FILE = "target/routing1/routingtest-Alert.log";
     private static final String ACTIVITY_LOG_FILE = "target/routing1/routingtest-Activity.log";
 
     private ListAppender app;
+    private LoggerContext context = null;
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
-
-    @Before
-    public void setUp() throws Exception {
-        this.app = this.loggerContextRule.getListAppender("List");
+    RoutingAppenderTest(LoggerContext context) {
+        this.context = context;
     }
+
+    @BeforeEach
+    public void beforeEach() {
+        new CleanFiles(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
+        this.app = context.getConfiguration().getAppender("List");
+    }
+    // @Before
+    // public void setUp() throws Exception {
+    //     this.app = this.loggerContextRule.getListAppender("List");
+    // }
 
     @After
     public void tearDown() throws Exception {
         this.app.clear();
-        this.loggerContextRule.getLoggerContext().stop();
+        this.app.stop();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -64,15 +64,15 @@ public class RoutingAppenderTest {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = app.getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Alert");
         EventLogger.logEvent(msg);
         File file = new File(ALERT_LOG_FILE);
-        assertTrue("Alert file was not created", file.exists());
+        assertTrue(file.exists(), "Alert file was not created");
         msg = new StructuredDataMessage("Test", "This is a test", "Activity");
         EventLogger.logEvent(msg);
         file = new File(ACTIVITY_LOG_FILE);
-        assertTrue("Activity file was not created", file.exists());
+        assertTrue(file.exists(), "Activity file was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.CleanFiles;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,17 +51,13 @@ public class RoutingAppenderTest {
     @BeforeEach
     public void beforeEach() {
         new CleanFiles(UNKNOWN_LOG_FILE, ALERT_LOG_FILE, ACTIVITY_LOG_FILE);
-        this.app = context.getConfiguration().getAppender("List");
+        this.app = this.context.getConfiguration().getAppender("List");
     }
-    // @Before
-    // public void setUp() throws Exception {
-    //     this.app = this.loggerContextRule.getListAppender("List");
-    // }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         this.app.clear();
-        this.app.stop();
+        this.context.stop();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Collections;
@@ -82,7 +82,7 @@ public class RoutingAppenderWithJndiTest {
                 new StructuredDataMessage("Test", "This is a message from unknown context", "Context");
         EventLogger.logEvent(msg);
         final File defaultLogFile = new File("target/routingbyjndi/routingbyjnditest-unknown.log");
-        assertTrue("The default log file was not created", defaultLogFile.exists());
+        assertTrue(defaultLogFile.exists(), "The default log file was not created");
 
         // now set jndi resource to Application1
         final Context context = new InitialContext();
@@ -90,38 +90,38 @@ public class RoutingAppenderWithJndiTest {
 
         msg = new StructuredDataMessage("Test", "This is a message from Application1", "Context");
         EventLogger.logEvent(msg);
-        assertNotNull("No events generated", listAppender1.getEvents());
+        assertNotNull(listAppender1.getEvents(), "No events generated");
         assertTrue(
+                listAppender1.getEvents().size() == 1,
                 "Incorrect number of events. Expected 1, got "
-                        + listAppender1.getEvents().size(),
-                listAppender1.getEvents().size() == 1);
+                        + listAppender1.getEvents().size());
 
         // now set jndi resource to Application2
         context.rebind(JNDI_CONTEXT_NAME, "Application2");
 
         msg = new StructuredDataMessage("Test", "This is a message from Application2", "Context");
         EventLogger.logEvent(msg);
-        assertNotNull("No events generated", listAppender2.getEvents());
+        assertNotNull(listAppender2.getEvents(), "No events generated");
         assertTrue(
+                listAppender2.getEvents().size() == 1,
                 "Incorrect number of events. Expected 1, got "
-                        + listAppender2.getEvents().size(),
-                listAppender2.getEvents().size() == 1);
+                        + listAppender2.getEvents().size());
         assertTrue(
+                listAppender1.getEvents().size() == 1,
                 "Incorrect number of events. Expected 1, got "
-                        + listAppender1.getEvents().size(),
-                listAppender1.getEvents().size() == 1);
+                        + listAppender1.getEvents().size());
 
         msg = new StructuredDataMessage("Test", "This is another message from Application2", "Context");
         EventLogger.logEvent(msg);
-        assertNotNull("No events generated", listAppender2.getEvents());
+        assertNotNull(listAppender2.getEvents(), "No events generated");
         assertTrue(
+                listAppender2.getEvents().size() == 2,
                 "Incorrect number of events. Expected 2, got "
-                        + listAppender2.getEvents().size(),
-                listAppender2.getEvents().size() == 2);
+                        + listAppender2.getEvents().size());
         assertTrue(
+                listAppender1.getEvents().size() == 1,
                 "Incorrect number of events. Expected 1, got "
-                        + listAppender1.getEvents().size(),
-                listAppender1.getEvents().size() == 1);
+                        + listAppender1.getEvents().size());
 
         // now set jndi resource to Application3.
         // The context name, 'Application3', will be used as log file name by the default route.
@@ -129,7 +129,7 @@ public class RoutingAppenderWithJndiTest {
         msg = new StructuredDataMessage("Test", "This is a message from Application3", "Context");
         EventLogger.logEvent(msg);
         final File application3LogFile = new File("target/routingbyjndi/routingbyjnditest-Application3.log");
-        assertTrue("The Application3 log file was not created", application3LogFile.exists());
+        assertTrue(application3LogFile.exists(), "The Application3 log file was not created");
 
         // now set jndi resource to Application4
         // The context name, 'Application4', will be used as log file name by the default route.
@@ -137,6 +137,6 @@ public class RoutingAppenderWithJndiTest {
         msg = new StructuredDataMessage("Test", "This is a message from Application4", "Context");
         EventLogger.logEvent(msg);
         final File application4LogFile = new File("target/routingbyjndi/routingbyjnditest-Application4.log");
-        assertTrue("The Application3 log file was not created", application4LogFile.exists());
+        assertTrue(application4LogFile.exists(), "The Application3 log file was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithPurgingTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithPurgingTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -81,8 +81,8 @@ public class RoutingAppenderWithPurgingTest {
         StructuredDataMessage msg = new StructuredDataMessage("1", "This is a test 1", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = app.getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("2", "This is a test 2", "Service");
         EventLogger.logEvent(msg);
         msg = new StructuredDataMessage("3", "This is a test 3", "Service");
@@ -100,67 +100,50 @@ public class RoutingAppenderWithPurgingTest {
                 .isEmpty());
 
         assertEquals(
-                "Incorrect number of appenders with IdlePurgePolicy.",
-                2,
-                routingAppenderIdle.getAppenders().size());
+                2, routingAppenderIdle.getAppenders().size(), "Incorrect number of appenders with IdlePurgePolicy.");
         assertEquals(
-                "Incorrect number of appenders with IdlePurgePolicy with HangingAppender.",
                 2,
-                routingAppenderIdleWithHangingAppender.getAppenders().size());
-        assertEquals(
-                "Incorrect number of appenders manual purge.",
-                2,
-                routingAppenderManual.getAppenders().size());
+                routingAppenderIdleWithHangingAppender.getAppenders().size(),
+                "Incorrect number of appenders with IdlePurgePolicy with HangingAppender.");
+        assertEquals(2, routingAppenderManual.getAppenders().size(), "Incorrect number of appenders manual purge.");
 
         Thread.sleep(3000);
         EventLogger.logEvent(msg);
 
         assertEquals(
-                "Incorrect number of appenders with IdlePurgePolicy.",
-                1,
-                routingAppenderIdle.getAppenders().size());
+                1, routingAppenderIdle.getAppenders().size(), "Incorrect number of appenders with IdlePurgePolicy.");
         assertEquals(
-                "Incorrect number of appenders with manual purge.",
-                2,
-                routingAppenderManual.getAppenders().size());
+                2, routingAppenderManual.getAppenders().size(), "Incorrect number of appenders with manual purge.");
 
         routingAppenderManual.deleteAppender("1");
         routingAppenderManual.deleteAppender("2");
         routingAppenderManual.deleteAppender("3");
 
         assertEquals(
-                "Incorrect number of appenders with IdlePurgePolicy.",
-                1,
-                routingAppenderIdle.getAppenders().size());
+                1, routingAppenderIdle.getAppenders().size(), "Incorrect number of appenders with IdlePurgePolicy.");
         assertEquals(
-                "Incorrect number of appenders with manual purge.",
-                0,
-                routingAppenderManual.getAppenders().size());
+                0, routingAppenderManual.getAppenders().size(), "Incorrect number of appenders with manual purge.");
 
         assertFalse(
-                "Reference based routes should not be stoppable",
-                loggerContextRule.getAppender("ReferencedList").isStopped());
+                loggerContextRule.getAppender("ReferencedList").isStopped(),
+                "Reference based routes should not be stoppable");
 
         msg = new StructuredDataMessage("5", "This is a test 5", "Service");
         EventLogger.logEvent(msg);
 
         assertEquals(
-                "Incorrect number of appenders with manual purge.",
-                1,
-                routingAppenderManual.getAppenders().size());
+                1, routingAppenderManual.getAppenders().size(), "Incorrect number of appenders with manual purge.");
 
         routingAppenderManual.deleteAppender("5");
         routingAppenderManual.deleteAppender("5");
 
         assertEquals(
-                "Incorrect number of appenders with manual purge.",
-                0,
-                routingAppenderManual.getAppenders().size());
+                0, routingAppenderManual.getAppenders().size(), "Incorrect number of appenders with manual purge.");
     }
 
     private void assertFileExistance(final String... files) {
         for (final String file : files) {
-            assertTrue("File should exist - " + file + " file ", new File(file).exists());
+            assertTrue(new File(file).exists(), "File should exist - " + file + " file ");
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
@@ -23,28 +23,32 @@ import java.io.File;
 import java.util.List;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.CleanFiles;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j-routing3.xml")
 public class RoutingDefaultAppenderTest {
     private static final String LOG_FILE = "target/routing1/routingtest.log";
 
-    private final LoggerContextRule loggerContextRule = new LoggerContextRule("log4j-routing3.xml");
-
-    @Rule
-    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILE);
+    @BeforeEach
+    public void beforeEach() {
+        new CleanFiles(LOG_FILE);
+    }
 
     @Test
-    public void routingTest() {
+    public void routingTest(final LoggerContext loggerContext) {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
-        final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
+        final ListAppender app = loggerContext.getConfiguration().getAppender("List");
+        final List<LogEvent> list = app.getEvents();
         assertNotNull(list, "No events generated");
         assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Alert");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -45,11 +45,11 @@ public class RoutingDefaultAppenderTest {
         StructuredDataMessage msg = new StructuredDataMessage("Test", "This is a test", "Service");
         EventLogger.logEvent(msg);
         final List<LogEvent> list = loggerContextRule.getListAppender("List").getEvents();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 1, "Incorrect number of events. Expected 1, got " + list.size());
         msg = new StructuredDataMessage("Test", "This is a test", "Alert");
         EventLogger.logEvent(msg);
         final File file = new File(LOG_FILE);
-        assertTrue("Alert file was not created", file.exists());
+        assertTrue(file.exists(), "Alert file was not created");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerArgumentFreedOnErrorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerArgumentFreedOnErrorTest.java
@@ -20,16 +20,15 @@ import static org.apache.logging.log4j.core.GcHelper.awaitGarbageCollection;
 
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 class AsyncLoggerArgumentFreedOnErrorTest {
 
     /**

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
@@ -16,30 +16,32 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test class loading deadlock condition from the LOG4J2-1457
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerClassLoadDeadlockTest {
 
     static final int RING_BUFFER_SIZE = 128;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
         System.setProperty("AsyncLogger.RingBufferSize", String.valueOf(RING_BUFFER_SIZE));
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConsoleTest.xml");
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testClassLoaderDeadlock() throws Exception {
         // touch the class so static init will be called
         final AsyncLoggerClassLoadDeadlock temp = new AsyncLoggerClassLoadDeadlock();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,15 +26,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigAutoFlushTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigAutoFlushTest.xml");
     }
@@ -42,7 +41,7 @@ public class AsyncLoggerConfigAutoFlushTest {
     @Test
     public void testFlushAtEndOfBatch() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigAutoFlushTest.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String msg = "Message flushed with immediate flush=false";
@@ -52,7 +51,7 @@ public class AsyncLoggerConfigAutoFlushTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertNotNull(line1, "line1");
+        assertTrue(line1.contains(msg), "line1 correct");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -29,18 +29,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.DefaultLogEventFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.AsynchronouslyFormattable;
 import org.apache.logging.log4j.message.Message;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigErrorOnFormat {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j2.enableThreadlocals", "true");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigErrorOnFormat.xml");
@@ -48,7 +47,7 @@ public class AsyncLoggerConfigErrorOnFormat {
         System.setProperty("log4j2.logEventFactory", DefaultLogEventFactory.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty("log4j2.enableThreadlocals");
         System.clearProperty("log4j2.logEventFactory");
@@ -57,7 +56,7 @@ public class AsyncLoggerConfigErrorOnFormat {
     @Test
     public void testError() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigErrorOnFormat.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         log.info(new ThrowsErrorOnFormatMessage());
@@ -71,7 +70,7 @@ public class AsyncLoggerConfigErrorOnFormat {
         file.delete();
 
         assertThat(line1, containsString("Second message"));
-        assertNull("Expected only one line", line2);
+        assertNull(line2, "Expected only one line");
     }
 
     @AsynchronouslyFormattable // Shouldn't call getFormattedMessage early

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,18 +27,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigTest2 {
 
     @Test
     public void testConsecutiveReconfigure() throws Exception {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest2.xml");
         final File file = new File("target", "AsyncLoggerConfigTest2.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String msg = "Message before reconfig";
@@ -57,9 +56,9 @@ public class AsyncLoggerConfigTest2 {
         final String line2 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1 " + line1, line1.contains(msg));
-        assertTrue("line2 " + line2, line2.contains(msg2));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.contains(msg), "line1 " + line1);
+        assertTrue(line2.contains(msg2), "line2 " + line2);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
@@ -21,18 +21,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigUseAfterShutdownTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest.xml");
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.async;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,16 +27,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerConfigWithAsyncEnabledTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j2.enableThreadlocals", "true");
         System.setProperty("log4j2.contextSelector", AsyncLoggerContextSelector.class.getCanonicalName());
@@ -44,7 +43,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest4.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty("log4j2.enableThreadlocals");
         System.clearProperty("log4j2.contextSelector");
@@ -53,7 +52,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
     @Test
     public void testParametersAreAvailableToLayout() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigTest4.log");
-        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+        assertTrue(!file.exists() || file.delete(), "Deleted old file before test");
 
         final Logger log = LogManager.getLogger("com.foo.Bar");
         final String format = "Additive logging: {} for the price of {}!";

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
@@ -16,16 +16,15 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerContextSelectorTest {
 
     private static final String FQCN = AsyncLoggerContextSelectorTest.class.getName();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextTest.java
@@ -20,14 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.MessageFactory2;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 class AsyncLoggerContextTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
@@ -33,19 +33,18 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.selector.ContextSelector;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerCustomSelectorLocationTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         final File file = new File("target", "AsyncLoggerCustomSelectorLocationTest.log");
         file.delete();
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, CustomAsyncContextSelector.class.getName());
@@ -53,8 +52,8 @@ public class AsyncLoggerCustomSelectorLocationTest {
                 ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerCustomSelectorLocationTest.xml");
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerDefaultLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerDefaultLocationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,23 +27,22 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerDefaultLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerDefaultLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -59,7 +58,7 @@ public class AsyncLoggerDefaultLocationTest {
         context.stop();
         assertEquals(1, app.getEvents().size());
         final LogEvent event = app.getEvents().get(0);
-        assertFalse("includeLocation should be false", event.isIncludeLocation());
-        assertNull("Location data should not be present", event.getSource());
+        assertFalse(event.isIncludeLocation(), "includeLocation should be false");
+        assertNull(event.getSource(), "Location data should not be present");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
@@ -26,14 +26,13 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ReusableSimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -43,7 +42,7 @@ import org.junit.jupiter.api.Test;
  *
  * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-2816">LOG4J2-2816</a>
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 class AsyncLoggerEventTranslationExceptionTest {
 
     @BeforeAll

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,18 +26,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         final File file = new File("target", "AsyncLoggerLocationTest.log");
         file.delete();
@@ -46,7 +45,7 @@ public class AsyncLoggerLocationTest {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -64,10 +63,10 @@ public class AsyncLoggerLocationTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertNotNull(line1, "line1");
+        assertTrue(line1.contains(msg), "line1 correct");
 
         final String location = "testAsyncLogWritesToLog";
-        assertTrue("has location", line1.contains(location));
+        assertTrue(line1.contains(location), "has location");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerNanoTimeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerNanoTimeTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,27 +27,26 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.DummyNanoClock;
 import org.apache.logging.log4j.core.util.SystemNanoClock;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerNanoTimeTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "NanoTimeToFileTest.xml");
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 
@@ -59,7 +58,7 @@ public class AsyncLoggerNanoTimeTest {
         final AsyncLogger log = (AsyncLogger) LogManager.getLogger("com.foo.Bar");
         final long before = System.nanoTime();
         log.info("Use actual System.nanoTime()");
-        assertTrue("using SystemNanoClock", log.getNanoClock() instanceof SystemNanoClock);
+        assertTrue(log.getNanoClock() instanceof SystemNanoClock, "using SystemNanoClock");
 
         final long DUMMYNANOTIME = -53;
         log.getContext().getConfiguration().setNanoClock(new DummyNanoClock(DUMMYNANOTIME));
@@ -69,7 +68,7 @@ public class AsyncLoggerNanoTimeTest {
         log.updateConfiguration(log.getContext().getConfiguration());
 
         log.info("Use dummy nano clock");
-        assertTrue("using SystemNanoClock", log.getNanoClock() instanceof DummyNanoClock);
+        assertTrue(log.getNanoClock() instanceof DummyNanoClock, "using SystemNanoClock");
 
         CoreLoggerContexts.stopLoggerContext(file); // stop async thread
 
@@ -87,7 +86,7 @@ public class AsyncLoggerNanoTimeTest {
         assertEquals("Use actual System.nanoTime()", line1Parts[2]);
         assertEquals(line1Parts[0], line1Parts[1]);
         final long loggedNanoTime = Long.parseLong(line1Parts[0]);
-        assertTrue("used system nano time", loggedNanoTime - before < TimeUnit.SECONDS.toNanos(1));
+        assertTrue(loggedNanoTime - before < TimeUnit.SECONDS.toNanos(1), "used system nano time");
 
         final String[] line2Parts = line2.split(" AND ");
         assertEquals("Use dummy nano clock", line2Parts[2]);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -25,25 +25,24 @@ import java.io.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.DummyNanoClock;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -65,11 +64,11 @@ public class AsyncLoggerTest {
         final String line1 = reader.readLine();
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertTrue("line1 correct", line1.contains(msg));
+        assertNotNull(line1, "line1");
+        assertTrue(line1.contains(msg), "line1 correct");
 
         final String location = "testAsyncLogWritesToLog";
-        assertTrue("no location", !line1.contains(location));
+        assertTrue(!line1.contains(location), "no location");
 
         assertTrue(LogManager.getFactory().isClassLoaderDependent());
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,24 +26,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTestCachedThreadName {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -67,9 +66,9 @@ public class AsyncLoggerTestCachedThreadName {
         // System.out.println(line2);
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1", line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
-        assertTrue("line2", line2.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line1");
+        assertTrue(line2.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line2");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,25 +26,24 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTestUncachedThreadName {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty("AsyncLogger.ThreadNameStrategy", "UNCACHED");
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -68,9 +67,9 @@ public class AsyncLoggerTestUncachedThreadName {
         // System.out.println(line2);
         reader.close();
         file.delete();
-        assertNotNull("line1", line1);
-        assertNotNull("line2", line2);
-        assertTrue("line1", line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "));
-        assertTrue("line2", line2.endsWith(" INFO c.f.Bar [MODIFIED-THREADNAME]   Async logger msg "));
+        assertNotNull(line1, "line1");
+        assertNotNull(line2, "line2");
+        assertTrue(line1.endsWith(" INFO c.f.Bar [main]   Async logger msg "), "line1");
+        assertTrue(line2.endsWith(" INFO c.f.Bar [MODIFIED-THREADNAME]   Async logger msg "), "line2");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
@@ -16,23 +16,22 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerThreadNameStrategyTest {
-    @After
+    @AfterEach
     public void after() {
         System.clearProperty("AsyncLogger.ThreadNameStrategy");
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         System.clearProperty("AsyncLogger.ThreadNameStrategy");
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTimestampMessageTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTimestampMessageTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Clock;
 import org.apache.logging.log4j.core.util.ClockFactory;
 import org.apache.logging.log4j.core.util.ClockFactoryTest;
@@ -36,10 +35,10 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.TimestampMessage;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Confirms that if you log a {@link TimestampMessage} then there are no unnecessary calls to {@link Clock}.
@@ -47,18 +46,18 @@ import org.junit.experimental.categories.Category;
  * See LOG4J2-744.
  * </p>
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerTimestampMessageTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTimestampMessageTest.xml");
         System.setProperty(ClockFactory.PROPERTY_NAME, PoisonClock.class.getName());
     }
 
-    @AfterClass
-    public static void afterClass() throws IllegalAccessException {
+    @AfterAll
+    public static void afterAll() throws IllegalAccessException {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
         ClockFactoryTest.resetClocks();
     }
@@ -80,7 +79,7 @@ public class AsyncLoggerTimestampMessageTest {
         reader.close();
         file.delete();
         assertNotNull(line1);
-        assertTrue("line1 correct", line1.equals("123456789000 Async logger msg with embedded timestamp"));
+        assertTrue(line1.equals("123456789000 Async logger msg with embedded timestamp"), "line1 correct");
     }
 
     public static class PoisonClock implements Clock {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
@@ -21,30 +21,29 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for https://issues.apache.org/jira/browse/LOG4J2-639
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggerUseAfterShutdownTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggersWithAsyncLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggersWithAsyncLoggerConfigTest.java
@@ -16,39 +16,38 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncLoggersWithAsyncLoggerConfigTest {
 
-    @ClassRule
-    public static LoggerContextRule context =
-            new LoggerContextRule("AsyncLoggersWithAsyncLoggerConfigTest.xml", AsyncLoggerContextSelector.class);
-
     @Test
-    public void testLoggingWorks() throws Exception {
+    @LoggerContextSource("AsyncLoggersWithAsyncLoggerConfigTest.xml")
+    public void testLoggingWorks(LoggerContext context) throws Exception {
         final Logger logger = LogManager.getLogger();
         logger.error("This is a test");
         logger.warn("Hello world!");
         Thread.sleep(100);
-        final List<String> list = context.getListAppender("List").getMessages();
-        assertNotNull("No events generated", list);
-        assertTrue("Incorrect number of events. Expected 2, got " + list.size(), list.size() == 2);
+        final ListAppender listAppender = context.getConfiguration().getAppender("List");
+        final List<String> list = listAppender.getMessages();
+
+        assertNotNull(list, "No events generated");
+        assertTrue(list.size() == 2, "Incorrect number of events. Expected 2, got " + list.size());
         String msg = list.get(0);
         String expected = getClass().getName() + " This is a test";
-        assertTrue("Expected " + expected + ", Actual " + msg, expected.equals(msg));
+        assertTrue(expected.equals(msg), "Expected " + expected + ", Actual " + msg);
         msg = list.get(1);
         expected = getClass().getName() + " Hello world!";
-        assertTrue("Expected " + expected + ", Actual " + msg, expected.equals(msg));
+        assertTrue(expected.equals(msg), "Expected " + expected + ", Actual " + msg);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -17,23 +17,22 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the AsyncQueueFullPolicyFactory class.
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncQueueFullPolicyFactoryTest {
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void resetProperties() throws Exception {
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER);
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_DISCARDING_THRESHOLD_LEVEL);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,23 +27,22 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncRootLoggerDefaultLocationTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncRootLoggerDefaultLocationTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
@@ -59,7 +58,7 @@ public class AsyncRootLoggerDefaultLocationTest {
         context.stop();
         assertEquals(1, app.getEvents().size());
         final LogEvent event = app.getEvents().get(0);
-        assertFalse("includeLocation should be false", event.isIncludeLocation());
-        assertNull("Location data should not be present", event.getSource());
+        assertFalse(event.isIncludeLocation(), "includeLocation should be false");
+        assertNull(event.getSource(), "Location data should not be present");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootReloadTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootReloadTest.java
@@ -21,28 +21,29 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.junit.CleanFiles;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.FileUtils;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.apache.logging.log4j.core.test.junit.Tags;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Tests LOG4J2-807.
  */
-@Category(AsyncLoggers.class)
+@Tag(Tags.ASYNC_LOGGERS)
+@LoggerContextSource("classpath:LOG4J2-807.xml")
 public class AsyncRootReloadTest {
 
     private static final String ISSUE = "LOG4J2-807";
     private static final String ISSUE_CONFIG = ISSUE + ".xml";
     private static final String LOG = "target/" + ISSUE + ".log";
-    private static final String RESOURCE = "classpath:" + ISSUE_CONFIG;
 
-    @ClassRule
-    public static RuleChain rules = RuleChain.outerRule(new CleanFiles(LOG)).around(new LoggerContextRule(RESOURCE));
+    @BeforeAll
+    private static void beforeAll() {
+        new CleanFiles(LOG);
+    }
 
     @Test
     public void testLog4j2_807() throws InterruptedException, URISyntaxException {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootReloadTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootReloadTest.java
@@ -23,11 +23,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.junit.CleanFiles;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.apache.logging.log4j.core.util.FileUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.apache.logging.log4j.core.test.junit.Tags;
+import org.apache.logging.log4j.core.util.FileUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests LOG4J2-807.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigGlobalLoggersTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigGlobalLoggersTest.java
@@ -23,31 +23,30 @@ import com.lmax.disruptor.YieldingWaitStrategy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncWaitStrategyFactoryConfigGlobalLoggersTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(
                 ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncWaitStrategyFactoryConfigGlobalLoggerTest.xml");
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
         System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
-    @Ignore("This test succeeds when run individually but fails when run by Surefire with all other tests")
+    @Disabled("This test succeeds when run individually but fails when run by Surefire with all other tests")
     @Test
     public void testConfigWaitStrategyAndFactory() throws Exception {
         final AsyncLogger logger = (AsyncLogger) LogManager.getLogger("com.foo.Bar");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
@@ -17,20 +17,19 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.YieldingWaitStrategy;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncWaitStrategyFactoryConfigTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
@@ -17,23 +17,22 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(
@@ -41,7 +40,7 @@ public class AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest {
                 "AsyncWaitStrategyIncorrectFactoryConfigGlobalLoggerTest.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
         System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelectorTest.java
@@ -16,33 +16,32 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class BasicAsyncLoggerContextSelectorTest {
 
     private static final String FQCN = BasicAsyncLoggerContextSelectorTest.class.getName();
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, BasicAsyncLoggerContextSelector.class.getName());
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DefaultAsyncQueueFullPolicyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DefaultAsyncQueueFullPolicyTest.java
@@ -16,17 +16,16 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the DefaultAsyncQueueFullPolicy class.
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class DefaultAsyncQueueFullPolicyTest {
 
     private static long currentThreadId() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DiscardingAsyncQueueFullPolicyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DiscardingAsyncQueueFullPolicyTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the DiscardingAsyncQueueFullPolicy class..
  */
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class DiscardingAsyncQueueFullPolicyTest {
 
     private static long currentThreadId() {
@@ -38,9 +38,11 @@ public class DiscardingAsyncQueueFullPolicyTest {
         return -1;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorDisallowsNullThresholdLevel() {
-        new DiscardingAsyncQueueFullPolicy(null);
+        assertThrows(NullPointerException.class, () -> {
+            new DiscardingAsyncQueueFullPolicy(null);
+        });
     }
 
     @Test
@@ -56,10 +58,10 @@ public class DiscardingAsyncQueueFullPolicyTest {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.WARN);
 
         for (final Level level : new Level[] {Level.WARN, Level.INFO, Level.DEBUG, Level.TRACE, Level.ALL}) {
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(currentThreadId(), level));
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(otherThreadId(), level));
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(currentThreadId(), level));
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(otherThreadId(), level));
+            assertEquals(EventRoute.DISCARD, router.getRoute(currentThreadId(), level), level.name());
+            assertEquals(EventRoute.DISCARD, router.getRoute(otherThreadId(), level), level.name());
+            assertEquals(EventRoute.DISCARD, router.getRoute(currentThreadId(), level), level.name());
+            assertEquals(EventRoute.DISCARD, router.getRoute(otherThreadId(), level), level.name());
         }
     }
 
@@ -68,8 +70,8 @@ public class DiscardingAsyncQueueFullPolicyTest {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.WARN);
 
         for (final Level level : new Level[] {Level.WARN, Level.INFO, Level.DEBUG, Level.TRACE, Level.ALL}) {
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(currentThreadId(), level));
-            assertEquals(level.name(), EventRoute.DISCARD, router.getRoute(otherThreadId(), level));
+            assertEquals(EventRoute.DISCARD, router.getRoute(currentThreadId(), level), level.name());
+            assertEquals(EventRoute.DISCARD, router.getRoute(otherThreadId(), level), level.name());
         }
     }
 
@@ -78,10 +80,10 @@ public class DiscardingAsyncQueueFullPolicyTest {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.WARN);
 
         for (final Level level : new Level[] {Level.ERROR, Level.FATAL, Level.OFF}) {
-            assertEquals(level.name(), EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level));
-            assertEquals(level.name(), EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level));
-            assertEquals(level.name(), EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level));
-            assertEquals(level.name(), EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level));
+            assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level), level.name());
+            assertEquals(EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level), level.name());
+            assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level), level.name());
+            assertEquals(EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level), level.name());
         }
     }
 
@@ -90,7 +92,7 @@ public class DiscardingAsyncQueueFullPolicyTest {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.WARN);
 
         for (final Level level : new Level[] {Level.ERROR, Level.FATAL, Level.OFF}) {
-            assertEquals(level.name(), EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level));
+            assertEquals(EventRoute.ENQUEUE, router.getRoute(otherThreadId(), level), level.name());
         }
     }
 
@@ -99,22 +101,22 @@ public class DiscardingAsyncQueueFullPolicyTest {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.WARN);
 
         for (final Level level : new Level[] {Level.ERROR, Level.FATAL, Level.OFF}) {
-            assertEquals(level.name(), EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level));
+            assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), level), level.name());
         }
     }
 
     @Test
     public void testGetDiscardCount() throws Exception {
         final DiscardingAsyncQueueFullPolicy router = new DiscardingAsyncQueueFullPolicy(Level.INFO);
-        assertEquals("initially", 0, DiscardingAsyncQueueFullPolicy.getDiscardCount(router));
+        assertEquals(0, DiscardingAsyncQueueFullPolicy.getDiscardCount(router), "initially");
 
         assertEquals(EventRoute.DISCARD, router.getRoute(-1L, Level.INFO));
-        assertEquals("increase", 1, DiscardingAsyncQueueFullPolicy.getDiscardCount(router));
+        assertEquals(1, DiscardingAsyncQueueFullPolicy.getDiscardCount(router), "increase");
 
         assertEquals(EventRoute.DISCARD, router.getRoute(-1L, Level.INFO));
-        assertEquals("increase", 2, DiscardingAsyncQueueFullPolicy.getDiscardCount(router));
+        assertEquals(2, DiscardingAsyncQueueFullPolicy.getDiscardCount(router), "increase");
 
         assertEquals(EventRoute.DISCARD, router.getRoute(-1L, Level.INFO));
-        assertEquals("increase", 3, DiscardingAsyncQueueFullPolicy.getDiscardCount(router));
+        assertEquals(3, DiscardingAsyncQueueFullPolicy.getDiscardCount(router), "increase");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688AsyncTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688AsyncTest.java
@@ -21,49 +21,42 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests LOG4J2-1688 Multiple loggings of arguments are setting these arguments to null.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class Log4j2Jira1688AsyncTest {
 
-    @BeforeClass
+    private ListAppender listAppender;
+
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "log4j-list.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule("log4j-list.xml");
-
-    private ListAppender listAppender;
-
-    @Before
-    public void before() throws Exception {
-        listAppender = context.getListAppender("List");
+    @BeforeEach
+    public void before(LoggerContext context) {
+        listAppender = context.getConfiguration().getAppender("List");
     }
 
     private static Object[] createArray(final int size) {
@@ -75,7 +68,8 @@ public class Log4j2Jira1688AsyncTest {
     }
 
     @Test
-    public void testLog4j2Only() throws InterruptedException {
+    @LoggerContextSource("log4j-list.xml")
+    public void testLog4j2Only(LoggerContext context) throws InterruptedException {
         final org.apache.logging.log4j.Logger log4JLogger = LogManager.getLogger(this.getClass());
         final int limit = 11; // more than unrolled varargs
         final Object[] args = createArray(limit);
@@ -85,9 +79,9 @@ public class Log4j2Jira1688AsyncTest {
         ((ExtendedLogger) log4JLogger).logIfEnabled("test", Level.ERROR, null, "test {}", args);
 
         listAppender.countDownLatch.await(1, TimeUnit.SECONDS);
-        Assert.assertArrayEquals(Arrays.toString(args), originalArgs, args);
+        Assertions.assertArrayEquals(originalArgs, args, Arrays.toString(args));
 
         ((ExtendedLogger) log4JLogger).logIfEnabled("test", Level.ERROR, null, "test {}", args);
-        Assert.assertArrayEquals(Arrays.toString(args), originalArgs, args);
+        Assertions.assertArrayEquals(originalArgs, args, Arrays.toString(args));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688Test.java
@@ -21,48 +21,41 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests LOG4J2-1688 Multiple loggings of arguments are setting these arguments to null.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@Tag("AsyncLoggers")
 public class Log4j2Jira1688Test {
 
-    @BeforeClass
+    private ListAppender listAppender;
+
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "log4j-list.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule("log4j-list.xml");
-
-    private ListAppender listAppender;
-
-    @Before
-    public void before() throws Exception {
-        listAppender = context.getListAppender("List");
+    @BeforeEach
+    public void before(LoggerContext context) {
+        listAppender = context.getConfiguration().getAppender("List");
     }
 
     private static Object[] createArray(final int size) {
@@ -74,7 +67,8 @@ public class Log4j2Jira1688Test {
     }
 
     @Test
-    public void testLog4j2Only() throws InterruptedException {
+    @LoggerContextSource("log4j-list.xml")
+    public void testLog4j2Only(LoggerContext context) throws InterruptedException {
         final org.apache.logging.log4j.Logger log4JLogger = LogManager.getLogger(this.getClass());
         final int limit = 11; // more than unrolled varargs
         final Object[] args = createArray(limit);
@@ -84,9 +78,9 @@ public class Log4j2Jira1688Test {
         ((ExtendedLogger) log4JLogger).logIfEnabled("test", Level.ERROR, null, "test {}", args);
 
         listAppender.countDownLatch.await(1, TimeUnit.SECONDS);
-        Assert.assertArrayEquals(Arrays.toString(args), originalArgs, args);
+        Assertions.assertArrayEquals(originalArgs, args, Arrays.toString(args));
 
         ((ExtendedLogger) log4JLogger).logIfEnabled("test", Level.ERROR, null, "test {}", args);
-        Assert.assertArrayEquals(Arrays.toString(args), originalArgs, args);
+        Assertions.assertArrayEquals(originalArgs, args, Arrays.toString(args));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
@@ -16,26 +16,23 @@
  */
 package org.apache.logging.log4j.core.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.filter.RegexFilter;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.core.util.Throwables;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
 public class CompositeConfigurationTest {
     /*
@@ -87,151 +84,94 @@ public class CompositeConfigurationTest {
         }
     */
     @Test
-    public void compositeLogger() {
-        final LoggerContextRule lcr = new LoggerContextRule("classpath:log4j-comp-logger.xml,log4j-comp-logger.json");
-        final Statement test = new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
-                Map<String, Appender> appendersMap = config.getLogger("cat1").getAppenders();
-                assertEquals(
-                        "Expected 2 Appender references for cat1 but got " + appendersMap.size(),
-                        2,
-                        appendersMap.size());
-                assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
+    @LoggerContextSource("classpath:log4j-comp-logger.xml,log4j-comp-logger.json")
+    public void compositeLogger(final LoggerContext lcr) {
+        final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+        Map<String, Appender> appendersMap = config.getLogger("cat1").getAppenders();
+        assertEquals(2, appendersMap.size(), "Expected 2 Appender references for cat1 but got " + appendersMap.size());
+        assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
 
-                final Filter loggerFilter = config.getLogger("cat1").getFilter();
-                assertTrue(loggerFilter instanceof RegexFilter);
-                assertEquals(loggerFilter.getOnMatch(), Filter.Result.DENY);
+        final Filter loggerFilter = config.getLogger("cat1").getFilter();
+        assertTrue(loggerFilter instanceof RegexFilter);
+        assertEquals(loggerFilter.getOnMatch(), Filter.Result.DENY);
 
-                appendersMap = config.getLogger("cat2").getAppenders();
-                assertEquals(
-                        "Expected 1 Appender reference for cat2 but got " + appendersMap.size(),
-                        1,
-                        appendersMap.size());
-                assertTrue(appendersMap.get("File") instanceof FileAppender);
+        appendersMap = config.getLogger("cat2").getAppenders();
+        assertEquals(1, appendersMap.size(), "Expected 1 Appender reference for cat2 but got " + appendersMap.size());
+        assertTrue(appendersMap.get("File") instanceof FileAppender);
 
-                appendersMap = config.getLogger("cat3").getAppenders();
-                assertEquals(
-                        "Expected 1 Appender reference for cat3 but got " + appendersMap.size(),
-                        1,
-                        appendersMap.size());
-                assertTrue(appendersMap.get("File") instanceof FileAppender);
+        appendersMap = config.getLogger("cat3").getAppenders();
+        assertEquals(1, appendersMap.size(), "Expected 1 Appender reference for cat3 but got " + appendersMap.size());
+        assertTrue(appendersMap.get("File") instanceof FileAppender);
 
-                appendersMap = config.getRootLogger().getAppenders();
-                assertEquals(
-                        "Expected 2 Appender references for the root logger but got " + appendersMap.size(),
-                        2,
-                        appendersMap.size());
-                assertTrue(appendersMap.get("File") instanceof FileAppender);
-                assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
+        appendersMap = config.getRootLogger().getAppenders();
+        assertEquals(
+                2,
+                appendersMap.size(),
+                "Expected 2 Appender references for the root logger but got " + appendersMap.size());
+        assertTrue(appendersMap.get("File") instanceof FileAppender);
+        assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
 
-                assertEquals(
-                        "Expected COMPOSITE_SOURCE for composite configuration but got "
-                                + config.getConfigurationSource(),
-                        config.getConfigurationSource(),
-                        ConfigurationSource.COMPOSITE_SOURCE);
-            }
-        };
-        runTest(lcr, test);
+        assertEquals(
+                config.getConfigurationSource(),
+                ConfigurationSource.COMPOSITE_SOURCE,
+                "Expected COMPOSITE_SOURCE for composite configuration but got " + config.getConfigurationSource());
     }
 
     @Test
-    public void testAttributeCheckWhenMergingConfigurations() {
-        final LoggerContextRule lcr =
-                new LoggerContextRule("classpath:log4j-comp-root-loggers.xml,log4j-comp-logger.json");
-        final Statement test = new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                try {
-                    final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
-                    Assert.assertNotNull(config);
-                } catch (final NullPointerException e) {
-                    fail("Should not throw NullPointerException when there are different nodes.");
-                }
-            }
-        };
-        runTest(lcr, test);
+    @LoggerContextSource("classpath:log4j-comp-root-loggers.xml,log4j-comp-logger.json")
+    public void testAttributeCheckWhenMergingConfigurations(final LoggerContext lcr) {
+        try {
+            final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+            assertNotNull(config);
+        } catch (final NullPointerException e) {
+            fail("Should not throw NullPointerException when there are different nodes.");
+        }
     }
 
     @Test
-    public void testAttributeMergeForLoggers() {
-        final LoggerContextRule lcr =
-                new LoggerContextRule("classpath:log4j-comp-logger-root.xml,log4j-comp-logger-attr-override.json");
-        final Statement test = new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
-                // Test for Root log level override
-                assertEquals(
-                        "Expected Root logger log level to be WARN",
-                        Level.WARN,
-                        config.getRootLogger().getLevel());
+    @LoggerContextSource("classpath:log4j-comp-logger-root.xml,log4j-comp-logger-attr-override.json")
+    public void testAttributeMergeForLoggers(final LoggerContext lcr) {
+        final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+        // Test for Root log level override
+        assertEquals(Level.WARN, config.getRootLogger().getLevel(), "Expected Root logger log level to be WARN");
 
-                // Test for cat2 level override
-                final LoggerConfig cat2 = config.getLogger("cat2");
-                assertEquals("Expected cat2 log level to be INFO", Level.INFO, cat2.getLevel());
+        // Test for cat2 level override
+        final LoggerConfig cat2 = config.getLogger("cat2");
+        assertEquals(Level.INFO, cat2.getLevel(), "Expected cat2 log level to be INFO");
 
-                // Test for cat2 additivity override
-                assertTrue("Expected cat2 additivity to be true", cat2.isAdditive());
+        // Test for cat2 additivity override
+        assertTrue(cat2.isAdditive(), "Expected cat2 additivity to be true");
 
-                // Regression
-                // Check level on cat3 (not present in root config)
-                assertEquals(
-                        "Expected cat3 log level to be ERROR",
-                        Level.ERROR,
-                        config.getLogger("cat3").getLevel());
-                // Check level on cat1 (not present in overridden config)
-                assertEquals(
-                        "Expected cat1 log level to be DEBUG",
-                        Level.DEBUG,
-                        config.getLogger("cat1").getLevel());
-            }
-        };
-        runTest(lcr, test);
+        // Regression
+        // Check level on cat3 (not present in root config)
+        assertEquals(Level.ERROR, config.getLogger("cat3").getLevel(), "Expected cat3 log level to be ERROR");
+        // Check level on cat1 (not present in overridden config)
+        assertEquals(Level.DEBUG, config.getLogger("cat1").getLevel(), "Expected cat1 log level to be DEBUG");
     }
 
     @Test
-    public void testMissingConfig() {
-        final LoggerContextRule lcr =
-                new LoggerContextRule("classpath:log4j-comp-logger-root.xml,log4j-does-not-exist.json");
-        final Statement test = new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                final AbstractConfiguration config = (AbstractConfiguration) lcr.getConfiguration();
-                assertNotNull("No configuration returned", config);
-                // Test for Root log level override
-                assertEquals(
-                        "Expected Root logger log level to be ERROR",
-                        Level.ERROR,
-                        config.getRootLogger().getLevel());
+    @LoggerContextSource("classpath:log4j-comp-logger-root.xml,log4j-does-not-exist.json")
+    public void testMissingConfig(final LoggerContext lcr) {
+        final AbstractConfiguration config = (AbstractConfiguration) lcr.getConfiguration();
+        assertNotNull(config, "No configuration returned");
+        // Test for Root log level override
+        assertEquals(Level.ERROR, config.getRootLogger().getLevel(), "Expected Root logger log level to be ERROR");
 
-                // Test for no cat2 level override
-                final LoggerConfig cat2 = config.getLogger("cat2");
-                assertEquals("Expected cat2 log level to be INFO", Level.DEBUG, cat2.getLevel());
-            }
-        };
-        runTest(lcr, test);
+        // Test for no cat2 level override
+        final LoggerConfig cat2 = config.getLogger("cat2");
+        assertEquals(Level.DEBUG, cat2.getLevel(), "Expected cat2 log level to be INFO");
     }
 
     @Test
-    public void testAppenderRefFilterMerge() {
-        final LoggerContextRule lcr =
-                new LoggerContextRule("classpath:log4j-comp-logger-ref.xml,log4j-comp-logger-ref.json");
-        final Statement test = new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+    @LoggerContextSource("classpath:log4j-comp-logger-ref.xml,log4j-comp-logger-ref.json")
+    public void testAppenderRefFilterMerge(final LoggerContext lcr) {
+        final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
 
-                final List<AppenderRef> appenderRefList =
-                        config.getLogger("cat1").getAppenderRefs();
-                final AppenderRef appenderRef = getAppenderRef(appenderRefList, "STDOUT");
-                assertTrue(
-                        "Expected cat1 STDOUT appenderRef to have a regex filter",
-                        appenderRef.getFilter() != null && appenderRef.getFilter() instanceof RegexFilter);
-            }
-        };
-        runTest(lcr, test);
+        final List<AppenderRef> appenderRefList = config.getLogger("cat1").getAppenderRefs();
+        final AppenderRef appenderRef = getAppenderRef(appenderRefList, "STDOUT");
+        assertTrue(
+                appenderRef.getFilter() != null && appenderRef.getFilter() instanceof RegexFilter,
+                "Expected cat1 STDOUT appenderRef to have a regex filter");
     }
 
     private AppenderRef getAppenderRef(final List<AppenderRef> appenderRefList, final String refName) {
@@ -289,17 +229,4 @@ public class CompositeConfigurationTest {
         runTest(rule, test);
 
     } */
-
-    private void runTest(final LoggerContextRule rule, final Statement statement) {
-        try {
-            rule.apply(
-                            statement,
-                            Description.createTestDescription(
-                                    getClass(),
-                                    Thread.currentThread().getStackTrace()[1].getMethodName()))
-                    .evaluate();
-        } catch (final Throwable e) {
-            Throwables.rethrow(e);
-        }
-    }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NestedLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NestedLoggerConfigTest.java
@@ -16,38 +16,29 @@
  */
 package org.apache.logging.log4j.core.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for LoggerConfig hierarchies.
  */
-@RunWith(Parameterized.class)
 public class NestedLoggerConfigTest {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static List<String> data() throws IOException {
-        return ImmutableList.of("logger-config/LoggerConfig/", "logger-config/AsyncLoggerConfig/");
+    public static Stream<String> data() {
+        return Stream.of("logger-config/LoggerConfig/", "logger-config/AsyncLoggerConfig/");
     }
 
-    private final String prefix;
-
-    public NestedLoggerConfigTest(final String prefix) {
-        this.prefix = prefix;
-    }
-
-    @Test
-    public void testInheritParentDefaultLevel() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void testInheritParentDefaultLevel(String prefix) throws IOException {
         final Configuration configuration = loadConfiguration(prefix + "default-level.xml");
         try {
             assertEquals(Level.ERROR, configuration.getLoggerConfig("com.foo").getLevel());
@@ -56,8 +47,9 @@ public class NestedLoggerConfigTest {
         }
     }
 
-    @Test
-    public void testInheritParentLevel() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void testInheritParentLevel(String prefix) throws IOException {
         final Configuration configuration = loadConfiguration(prefix + "inherit-level.xml");
         try {
             assertEquals(Level.TRACE, configuration.getLoggerConfig("com.foo").getLevel());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/DateTypeConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/DateTypeConverterTest.java
@@ -21,39 +21,29 @@ import static org.junit.Assert.assertEquals;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Date;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class DateTypeConverterTest {
 
-    private final Class<? extends Date> dateClass;
-    private final long timestamp;
-    private final Object expected;
-
-    @Parameterized.Parameters
-    public static Object[][] data() {
+    static Stream<Arguments> data() {
         final long millis = System.currentTimeMillis();
-        return new Object[][] {
-            {Date.class, millis, new Date(millis)},
-            {java.sql.Date.class, millis, new java.sql.Date(millis)},
-            {Time.class, millis, new Time(millis)},
-            {Timestamp.class, millis, new Timestamp(millis)}
-        };
+        return Stream.of(
+                Arguments.of(Date.class, millis, new Date(millis)),
+                Arguments.of(java.sql.Date.class, millis, new java.sql.Date(millis)),
+                Arguments.of(Time.class, millis, new Time(millis)),
+                Arguments.of(Timestamp.class, millis, new Timestamp(millis)));
     }
 
-    public DateTypeConverterTest(final Class<? extends Date> dateClass, final long timestamp, final Object expected) {
-        this.dateClass = dateClass;
-        this.timestamp = timestamp;
-        this.expected = expected;
-    }
-
-    @Test
-    public void testFromMillis() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFromMillis(final Class<? extends Date> dateClass, final long timestamp, final Object expected)
+            throws Exception {
         assertEquals(expected, DateTypeConverter.fromMillis(timestamp, dateClass));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistryTest.java
@@ -16,19 +16,22 @@
  */
 package org.apache.logging.log4j.core.config.plugins.convert;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TypeConverterRegistryTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testFindNullConverter() {
-        TypeConverterRegistry.getInstance().findCompatibleConverter(null);
+        assertThrows(NullPointerException.class, () -> {
+            TypeConverterRegistry.getInstance().findCompatibleConverter(null);
+        });
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConvertersTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConvertersTest.java
@@ -30,194 +30,177 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
 import java.security.Security;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.appender.rolling.action.Duration;
 import org.apache.logging.log4j.core.layout.GelfLayout;
 import org.apache.logging.log4j.core.net.Facility;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link TypeConverters}.
  */
-@RunWith(Parameterized.class)
 public class TypeConvertersTest {
 
     @SuppressWarnings("boxing")
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() throws Exception {
+    public static Stream<Arguments> data() throws Exception {
         final byte[] byteArray = {
             (byte) 0xc7, (byte) 0x73, (byte) 0x21, (byte) 0x8c, (byte) 0x7e, (byte) 0xc8, (byte) 0xee, (byte) 0x99
         };
-        return Arrays.asList(
-                // Array format: value, expected, default, type
-                new Object[][] {
-                    // boolean
-                    {"true", true, null, Boolean.class},
-                    {"false", false, null, Boolean.class},
-                    {"True", true, null, Boolean.class},
-                    {"TRUE", true, null, Boolean.class},
-                    {"blah", false, null, Boolean.class
-                    }, // TODO: is this acceptable? it's how Boolean.parseBoolean works
-                    {null, null, null, Boolean.class},
-                    {null, true, "true", Boolean.class},
-                    {"no", false, null, Boolean.class}, // TODO: see above
-                    {"true", true, "false", boolean.class},
-                    {"FALSE", false, "true", boolean.class},
-                    {null, false, "false", boolean.class},
-                    {"invalid", false, "false", boolean.class},
-                    // byte
-                    {"42", (byte) 42, null, Byte.class},
-                    {"53", (byte) 53, null, Byte.class},
-                    // char
-                    {"A", 'A', null, char.class},
-                    {"b", 'b', null, char.class},
-                    {"b0", null, null, char.class},
-                    // integer
-                    {"42", 42, null, Integer.class},
-                    {"53", 53, null, Integer.class},
-                    {"-16", -16, null, Integer.class},
-                    {"0", 0, null, Integer.class},
-                    {"n", null, null, Integer.class},
-                    {"n", 5, "5", Integer.class},
-                    {"4.2", null, null, Integer.class},
-                    {"4.2", 0, "0", Integer.class},
-                    {null, null, null, Integer.class},
-                    {"75", 75, "0", int.class},
-                    {"-30", -30, "0", int.class},
-                    {"0", 0, "10", int.class},
-                    {null, 10, "10", int.class},
-                    // longs
-                    {"55", 55L, null, Long.class},
-                    {"1234567890123456789", 1234567890123456789L, null, Long.class},
-                    {"123123123L", null, null, Long.class},
-                    {"123123123123", 123123123123L, null, Long.class},
-                    {"-987654321", -987654321L, null, Long.class},
-                    {"-45l", null, null, Long.class},
-                    {"0", 0L, null, Long.class},
-                    {"asdf", null, null, Long.class},
-                    {"3.14", null, null, Long.class},
-                    {"3.14", 0L, "0", Long.class},
-                    {"*3", 1000L, "1000", Long.class},
-                    {null, null, null, Long.class},
-                    {"3000", 3000L, "0", long.class},
-                    {"-543210", -543210L, "0", long.class},
-                    {"22.7", -53L, "-53", long.class},
-                    // short
-                    {"42", (short) 42, null, short.class},
-                    {"53", (short) 53, null, short.class},
-                    {"-16", (short) -16, null, Short.class},
-                    // Log4j
-                    // levels
-                    {"ERROR", Level.ERROR, null, Level.class},
-                    {"WARN", Level.WARN, null, Level.class},
-                    {"FOO", null, null, Level.class},
-                    {"FOO", Level.DEBUG, "DEBUG", Level.class},
-                    {"OFF", Level.OFF, null, Level.class},
-                    {null, null, null, Level.class},
-                    {null, Level.INFO, "INFO", Level.class},
-                    // results
-                    {"ACCEPT", Filter.Result.ACCEPT, null, Filter.Result.class},
-                    {"NEUTRAL", Filter.Result.NEUTRAL, null, Filter.Result.class},
-                    {"DENY", Filter.Result.DENY, null, Filter.Result.class},
-                    {"NONE", null, null, Filter.Result.class},
-                    {"NONE", Filter.Result.NEUTRAL, "NEUTRAL", Filter.Result.class},
-                    {null, null, null, Filter.Result.class},
-                    {null, Filter.Result.ACCEPT, "ACCEPT", Filter.Result.class},
-                    // syslog facilities
-                    {"KERN", Facility.KERN, "USER", Facility.class},
-                    {"mail", Facility.MAIL, "KERN", Facility.class},
-                    {"Cron", Facility.CRON, null, Facility.class},
-                    {"not a real facility", Facility.AUTH, "auth", Facility.class},
-                    {null, null, null, Facility.class},
-                    // GELF compression types
-                    {"GZIP", GelfLayout.CompressionType.GZIP, "GZIP", GelfLayout.CompressionType.class},
-                    {"ZLIB", GelfLayout.CompressionType.ZLIB, "GZIP", GelfLayout.CompressionType.class},
-                    {"OFF", GelfLayout.CompressionType.OFF, "GZIP", GelfLayout.CompressionType.class},
-                    // arrays
-                    {"123", "123".toCharArray(), null, char[].class},
-                    {"123", "123".getBytes(Charset.defaultCharset()), null, byte[].class},
-                    {"0xC773218C7EC8EE99", byteArray, null, byte[].class},
-                    {"0xc773218c7ec8ee99", byteArray, null, byte[].class},
-                    {"Base64:cGxlYXN1cmUu", "pleasure.".getBytes("US-ASCII"), null, byte[].class},
-                    // JRE
-                    // JRE Charset
-                    {"UTF-8", StandardCharsets.UTF_8, null, Charset.class},
-                    {"ASCII", Charset.forName("ASCII"), "UTF-8", Charset.class},
-                    {"Not a real charset", StandardCharsets.UTF_8, "UTF-8", Charset.class},
-                    {null, StandardCharsets.UTF_8, "UTF-8", Charset.class},
-                    {null, null, null, Charset.class},
-                    // JRE File
-                    {"c:/temp", new File("c:/temp"), null, File.class},
-                    // JRE Class
-                    {TypeConvertersTest.class.getName(), TypeConvertersTest.class, null, Class.class},
-                    {"boolean", boolean.class, null, Class.class},
-                    {"byte", byte.class, null, Class.class},
-                    {"char", char.class, null, Class.class},
-                    {"double", double.class, null, Class.class},
-                    {"float", float.class, null, Class.class},
-                    {"int", int.class, null, Class.class},
-                    {"long", long.class, null, Class.class},
-                    {"short", short.class, null, Class.class},
-                    {"void", void.class, null, Class.class},
-                    {"\t", Object.class, Object.class.getName(), Class.class},
-                    {"\n", null, null, Class.class},
-                    // JRE URL
-                    {"http://locahost", new URL("http://locahost"), null, URL.class},
-                    {"\n", null, null, URL.class},
-                    // JRE URI
-                    {"http://locahost", new URI("http://locahost"), null, URI.class},
-                    {"\n", null, null, URI.class},
-                    // JRE BigInteger
-                    {"9223372036854775817000", new BigInteger("9223372036854775817000"), null, BigInteger.class},
-                    {"\n", null, null, BigInteger.class},
-                    // JRE BigInteger
-                    {
+        return Stream.of(
+                // Format: value, expected, default, type
+                // boolean
+                Arguments.of("true", true, null, Boolean.class),
+                Arguments.of("false", false, null, Boolean.class),
+                Arguments.of("True", true, null, Boolean.class),
+                Arguments.of("TRUE", true, null, Boolean.class),
+                Arguments.of("blah", false, null, Boolean.class),
+                // TODO: is this acceptable? it's how Boolean.parseBoolean works
+                Arguments.of(null, null, null, Boolean.class),
+                Arguments.of(null, true, "true", Boolean.class),
+                Arguments.of("no", false, null, Boolean.class), // TODO: see above
+                Arguments.of("true", true, "false", boolean.class),
+                Arguments.of("FALSE", false, "true", boolean.class),
+                Arguments.of(null, false, "false", boolean.class),
+                Arguments.of("invalid", false, "false", boolean.class),
+                // byte
+                Arguments.of("42", (byte) 42, null, Byte.class),
+                Arguments.of("53", (byte) 53, null, Byte.class),
+                // char
+                Arguments.of("A", 'A', null, char.class),
+                Arguments.of("b", 'b', null, char.class),
+                Arguments.of("b0", null, null, char.class),
+                // integer
+                Arguments.of("42", 42, null, Integer.class),
+                Arguments.of("53", 53, null, Integer.class),
+                Arguments.of("-16", -16, null, Integer.class),
+                Arguments.of("0", 0, null, Integer.class),
+                Arguments.of("n", null, null, Integer.class),
+                Arguments.of("n", 5, "5", Integer.class),
+                Arguments.of("4.2", null, null, Integer.class),
+                Arguments.of("4.2", 0, "0", Integer.class),
+                Arguments.of(null, null, null, Integer.class),
+                Arguments.of("75", 75, "0", int.class),
+                Arguments.of("-30", -30, "0", int.class),
+                Arguments.of("0", 0, "10", int.class),
+                Arguments.of(null, 10, "10", int.class),
+                // longs
+                Arguments.of("55", 55L, null, Long.class),
+                Arguments.of("1234567890123456789", 1234567890123456789L, null, Long.class),
+                Arguments.of("123123123L", null, null, Long.class),
+                Arguments.of("123123123123", 123123123123L, null, Long.class),
+                Arguments.of("-987654321", -987654321L, null, Long.class),
+                Arguments.of("-45l", null, null, Long.class),
+                Arguments.of("0", 0L, null, Long.class),
+                Arguments.of("asdf", null, null, Long.class),
+                Arguments.of("3.14", null, null, Long.class),
+                Arguments.of("3.14", 0L, "0", Long.class),
+                Arguments.of("*3", 1000L, "1000", Long.class),
+                Arguments.of(null, null, null, Long.class),
+                Arguments.of("3000", 3000L, "0", long.class),
+                Arguments.of("-543210", -543210L, "0", long.class),
+                Arguments.of("22.7", -53L, "-53", long.class),
+                // short
+                Arguments.of("42", (short) 42, null, short.class),
+                Arguments.of("53", (short) 53, null, short.class),
+                Arguments.of("-16", (short) -16, null, Short.class),
+                // Log4j
+                // levels
+                Arguments.of("ERROR", Level.ERROR, null, Level.class),
+                Arguments.of("WARN", Level.WARN, null, Level.class),
+                Arguments.of("FOO", null, null, Level.class),
+                Arguments.of("FOO", Level.DEBUG, "DEBUG", Level.class),
+                Arguments.of("OFF", Level.OFF, null, Level.class),
+                Arguments.of(null, null, null, Level.class),
+                Arguments.of(null, Level.INFO, "INFO", Level.class),
+                // results
+                Arguments.of("ACCEPT", Filter.Result.ACCEPT, null, Filter.Result.class),
+                Arguments.of("NEUTRAL", Filter.Result.NEUTRAL, null, Filter.Result.class),
+                Arguments.of("DENY", Filter.Result.DENY, null, Filter.Result.class),
+                Arguments.of("NONE", null, null, Filter.Result.class),
+                Arguments.of("NONE", Filter.Result.NEUTRAL, "NEUTRAL", Filter.Result.class),
+                Arguments.of(null, null, null, Filter.Result.class),
+                Arguments.of(null, Filter.Result.ACCEPT, "ACCEPT", Filter.Result.class),
+                // syslog facilities
+                Arguments.of("KERN", Facility.KERN, "USER", Facility.class),
+                Arguments.of("mail", Facility.MAIL, "KERN", Facility.class),
+                Arguments.of("Cron", Facility.CRON, null, Facility.class),
+                Arguments.of("not a real facility", Facility.AUTH, "auth", Facility.class),
+                Arguments.of(null, null, null, Facility.class),
+                // GELF compression types
+                Arguments.of("GZIP", GelfLayout.CompressionType.GZIP, "GZIP", GelfLayout.CompressionType.class),
+                Arguments.of("ZLIB", GelfLayout.CompressionType.ZLIB, "GZIP", GelfLayout.CompressionType.class),
+                Arguments.of("OFF", GelfLayout.CompressionType.OFF, "GZIP", GelfLayout.CompressionType.class),
+                // arrays
+                Arguments.of("123", "123".toCharArray(), null, char[].class),
+                Arguments.of("123", "123".getBytes(Charset.defaultCharset()), null, byte[].class),
+                Arguments.of("0xC773218C7EC8EE99", byteArray, null, byte[].class),
+                Arguments.of("0xc773218c7ec8ee99", byteArray, null, byte[].class),
+                Arguments.of("Base64:cGxlYXN1cmUu", "pleasure.".getBytes("US-ASCII"), null, byte[].class),
+                // JRE
+                // JRE Charset
+                Arguments.of("UTF-8", StandardCharsets.UTF_8, null, Charset.class),
+                Arguments.of("ASCII", Charset.forName("ASCII"), "UTF-8", Charset.class),
+                Arguments.of("Not a real charset", StandardCharsets.UTF_8, "UTF-8", Charset.class),
+                Arguments.of(null, StandardCharsets.UTF_8, "UTF-8", Charset.class),
+                Arguments.of(null, null, null, Charset.class),
+                // JRE File
+                Arguments.of("c:/temp", new File("c:/temp"), null, File.class),
+                // JRE Class
+                Arguments.of(TypeConvertersTest.class.getName(), TypeConvertersTest.class, null, Class.class),
+                Arguments.of("boolean", boolean.class, null, Class.class),
+                Arguments.of("byte", byte.class, null, Class.class),
+                Arguments.of("char", char.class, null, Class.class),
+                Arguments.of("double", double.class, null, Class.class),
+                Arguments.of("float", float.class, null, Class.class),
+                Arguments.of("int", int.class, null, Class.class),
+                Arguments.of("long", long.class, null, Class.class),
+                Arguments.of("short", short.class, null, Class.class),
+                Arguments.of("void", void.class, null, Class.class),
+                Arguments.of("\t", Object.class, Object.class.getName(), Class.class),
+                Arguments.of("\n", null, null, Class.class),
+                // JRE URL
+                Arguments.of("http://locahost", new URL("http://locahost"), null, URL.class),
+                Arguments.of("\n", null, null, URL.class),
+                // JRE URI
+                Arguments.of("http://locahost", new URI("http://locahost"), null, URI.class),
+                Arguments.of("\n", null, null, URI.class),
+                // JRE BigInteger
+                Arguments.of(
+                        "9223372036854775817000", new BigInteger("9223372036854775817000"), null, BigInteger.class),
+                Arguments.of("\n", null, null, BigInteger.class),
+                // JRE BigInteger
+                Arguments.of(
                         "9223372036854775817000.99999",
                         new BigDecimal("9223372036854775817000.99999"),
                         null,
-                        BigDecimal.class
-                    },
-                    {"\n", null, null, BigDecimal.class},
-                    // JRE Security Provider
-                    {Security.getProviders()[0].getName(), Security.getProviders()[0], null, Provider.class},
-                    {"\n", null, null, Provider.class},
-                    // Duration
-                    {"P7DT10H", Duration.parse("P7DT10H"), null, Duration.class},
-                    // JRE InetAddress
-                    {"127.0.0.1", InetAddress.getByName("127.0.0.1"), null, InetAddress.class},
-                    // JRE Path
-                    {"/path/to/file", Paths.get("/path", "to", "file"), null, Path.class},
-                    // JRE UUID
-                    {
+                        BigDecimal.class),
+                Arguments.of("\n", null, null, BigDecimal.class),
+                // JRE Security Provider
+                Arguments.of(Security.getProviders()[0].getName(), Security.getProviders()[0], null, Provider.class),
+                Arguments.of("\n", null, null, Provider.class),
+                // Duration
+                Arguments.of("P7DT10H", Duration.parse("P7DT10H"), null, Duration.class),
+                // JRE InetAddress
+                Arguments.of("127.0.0.1", InetAddress.getByName("127.0.0.1"), null, InetAddress.class),
+                // JRE Path
+                Arguments.of("/path/to/file", Paths.get("/path", "to", "file"), null, Path.class),
+                // JRE UUID
+                Arguments.of(
                         "8fd389fb-9154-4096-b52e-435bde4a1835",
                         UUID.fromString("8fd389fb-9154-4096-b52e-435bde4a1835"),
                         null,
-                        UUID.class
-                    },
-                });
+                        UUID.class));
     }
 
-    private final String value;
-    private final Object expected;
-    private final String defaultValue;
-    private final Class<?> clazz;
-
-    public TypeConvertersTest(
-            final String value, final Object expected, final String defaultValue, final Class<?> clazz) {
-        this.value = value;
-        this.expected = expected;
-        this.defaultValue = defaultValue;
-        this.clazz = clazz;
-    }
-
-    @Test
-    public void testConvert() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testConvert(final String value, final Object expected, final String defaultValue, final Class<?> clazz)
+            throws Exception {
         final Object actual = TypeConverters.convert(value, clazz, defaultValue);
         final String assertionMessage = "\nGiven: " + value + "\nDefault: " + defaultValue;
         assertThat(actual).as(assertionMessage).isEqualTo(expected);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.logging.log4j.core.config.plugins.processor;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnit4.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginCacheTest {
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
@@ -17,29 +17,29 @@
 package org.apache.logging.log4j.core.config.plugins.processor;
 
 import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Map;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAliases;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnit4.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginProcessorTest {
 
     private static final PluginCache pluginCache = new PluginCache();
 
     private final Plugin p = FakePlugin.class.getAnnotation(Plugin.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception {
         final Enumeration<URL> resources =
                 PluginProcessor.class.getClassLoader().getResources(PluginProcessor.PLUGIN_CACHE_FILE);
@@ -48,10 +48,10 @@ public class PluginProcessorTest {
 
     @Test
     public void testTestCategoryFound() throws Exception {
-        assertNotNull("No plugin annotation on FakePlugin.", p);
+        assertNotNull(p, "No plugin annotation on FakePlugin.");
         final Map<String, PluginEntry> testCategory = pluginCache.getCategory(p.category());
-        assertNotEquals("No plugins were found.", 0, pluginCache.size());
-        assertNotNull("The category '" + p.category() + "' was not found.", testCategory);
+        assertNotEquals(0, pluginCache.size(), "No plugins were found.");
+        assertNotNull(testCategory, "The category '" + p.category() + "' was not found.");
         assertFalse(testCategory.isEmpty());
     }
 
@@ -71,7 +71,7 @@ public class PluginProcessorTest {
     }
 
     private void verifyFakePluginEntry(final String name, final PluginEntry fake) {
-        assertNotNull("The plugin '" + toRootLowerCase(name) + "' was not found.", fake);
+        assertNotNull(fake, "The plugin '" + toRootLowerCase(name) + "' was not found.");
         assertEquals(FakePlugin.class.getName(), fake.getClassName());
         assertEquals(toRootLowerCase(name), fake.getKey());
         assertEquals(Plugin.EMPTY, p.elementType());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/util/ResolverUtilCustomProtocolTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/util/ResolverUtilCustomProtocolTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.config.plugins.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -91,7 +91,7 @@ public class ResolverUtilCustomProtocolTest {
                 oldFactory = (URLStreamHandlerFactory) factoryField.get(null);
             }
         }
-        assertThat(factoryField).as("java.net.URL#factory field").isNotNull();
+        assertNotNull(factoryField, "java.net.URL#factory field is null");
         URL.setURLStreamHandlerFactory(new NoopURLStreamHandlerFactory());
     }
 
@@ -174,7 +174,7 @@ public class ResolverUtilCustomProtocolTest {
     @MethodSource
     public void testExtractedPath(final String urlAsString, final String expected) throws Exception {
         final URL url = new URL(urlAsString);
-        assertThat(new ResolverUtil().extractPath(url)).isEqualTo(expected);
+        assertEquals(new ResolverUtil().extractPath(url), expected);
     }
 
     @Test
@@ -184,12 +184,11 @@ public class ResolverUtilCustomProtocolTest {
             final ResolverUtil resolverUtil = new ResolverUtil();
             resolverUtil.setClassLoader(new SingleURLClassLoader(new URL("vfs:/" + tmpDir + "/customplugin3/"), cl));
             resolverUtil.findInPackage(new PluginTest(), "customplugin3");
+            assertEquals(1, resolverUtil.getClasses().size(), "Class not found in packages");
             assertEquals(
-                    "Class not found in packages", 1, resolverUtil.getClasses().size());
-            assertEquals(
-                    "Unexpected class resolved",
                     cl.loadClass("customplugin3.FixedString3Layout"),
-                    resolverUtil.getClasses().iterator().next());
+                    resolverUtil.getClasses().iterator().next(),
+                    "Unexpected class resolved");
         }
     }
 
@@ -201,12 +200,11 @@ public class ResolverUtilCustomProtocolTest {
             resolverUtil.setClassLoader(
                     new SingleURLClassLoader(new URL("vfs:/" + tmpDir + "/customplugin4.jar/customplugin4/"), cl));
             resolverUtil.findInPackage(new PluginTest(), "customplugin4");
+            assertEquals(1, resolverUtil.getClasses().size(), "Class not found in packages");
             assertEquals(
-                    "Class not found in packages", 1, resolverUtil.getClasses().size());
-            assertEquals(
-                    "Unexpected class resolved",
                     cl.loadClass("customplugin4.FixedString4Layout"),
-                    resolverUtil.getClasses().iterator().next());
+                    resolverUtil.getClasses().iterator().next(),
+                    "Unexpected class resolved");
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -29,33 +29,30 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for LOG4J2-2368.
  */
+@LoggerContextSource("log4j-nested-logging-throwable-message.xml")
 public class NestedLoggingFromThrowableMessageTest {
 
     private static final File file1 = new File("target/NestedLoggerTest1.log");
     private static final File file2 = new File("target/NestedLoggerTest2.log");
 
-    @BeforeClass
-    public static void beforeClass() {
-        file1.delete();
-        file2.delete();
+    @BeforeAll
+    public static void beforeAll() {
+        // file1.delete();
+        // file2.delete();
         System.setProperty("log4j2.enableThreadlocals", "true");
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule("log4j-nested-logging-throwable-message.xml");
-
     private Logger logger;
 
-    @Before
+    @BeforeEach
     public void before() {
         logger = LogManager.getLogger(NestedLoggingFromThrowableMessageTest.class);
     }
@@ -79,7 +76,7 @@ public class NestedLoggingFromThrowableMessageTest {
         final Set<String> lines1 = readUniqueLines(file1);
         final Set<String> lines2 = readUniqueLines(file2);
 
-        assertEquals("Expected the same data from both appenders", lines1, lines2);
+        assertEquals(lines1, lines2, "Expected the same data from both appenders");
         assertEquals(2, lines1.size());
         assertTrue(lines1.contains("INFO NestedLoggingFromThrowableMessageTest Logging in getMessage "));
         assertTrue(lines1.contains("ERROR NestedLoggingFromThrowableMessageTest Test message"));
@@ -91,7 +88,7 @@ public class NestedLoggingFromThrowableMessageTest {
                 new BufferedReader(new InputStreamReader(Files.newInputStream(input.toPath())))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                assertTrue("Read duplicate line: " + line, lines.add(line));
+                assertTrue(lines.add(line), "Read duplicate line: " + line);
             }
         }
         return lines;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjectorTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.core.impl;
 
-import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.apache.logging.log4j.core.impl.ContextDataInjectorFactory.createInjector;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,8 +27,8 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.util.Collection;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.spi.ThreadContextMap;
@@ -37,25 +36,18 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ProviderUtil;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ThreadContextDataInjectorTest {
-    @Parameters(name = "{0}")
-    public static Collection<String[]> threadContextMapClassNames() {
-        return asList(new String[][] {
-            {"org.apache.logging.log4j.core.context.internal.GarbageFreeSortedArrayThreadContextMap"},
-            {"org.apache.logging.log4j.spi.DefaultThreadContextMap"}
-        });
+
+    public static Stream<String> threadContextMapClassNames() {
+        return Stream.of(
+                "org.apache.logging.log4j.core.context.internal.GarbageFreeSortedArrayThreadContextMap",
+                "org.apache.logging.log4j.spi.DefaultThreadContextMap");
     }
 
-    @Parameter
     public String threadContextMapClassName;
 
     private static void resetThreadContextMap() {
@@ -65,12 +57,7 @@ public class ThreadContextDataInjectorTest {
         ThreadContext.init();
     }
 
-    @Before
-    public void before() throws ReflectiveOperationException {
-        System.setProperty("log4j2.threadContextMap", threadContextMapClassName);
-    }
-
-    @After
+    @AfterEach
     public void after() {
         ThreadContext.remove("foo");
         ThreadContext.remove("baz");
@@ -121,14 +108,20 @@ public class ThreadContextDataInjectorTest {
         ThreadContext.put("foo", "bar");
     }
 
-    @Test
-    public void testThreadContextImmutability() {
+    @ParameterizedTest
+    @MethodSource("threadContextMapClassNames")
+    public void testThreadContextImmutability(final String name) {
+        System.setProperty("log4j2.threadContextMap", name);
+        this.threadContextMapClassName = name;
         prepareThreadContext(false);
         testContextDataInjector();
     }
 
-    @Test
-    public void testInheritableThreadContextImmutability() throws Throwable {
+    @ParameterizedTest
+    @MethodSource("threadContextMapClassNames")
+    public void testInheritableThreadContextImmutability(final String name) throws Throwable {
+        System.setProperty("log4j2.threadContextMap", name);
+        this.threadContextMapClassName = name;
         prepareThreadContext(true);
         try {
             newSingleThreadExecutor().submit(this::testContextDataInjector).get();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429MyNamesTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429MyNamesTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.jackson;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,13 +31,11 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import java.io.IOException;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class JacksonIssue429MyNamesTest {
 
     @SuppressWarnings("serial")
@@ -114,9 +115,9 @@ public class JacksonIssue429MyNamesTest {
                 aposToQuotes(
                         "{'Location':{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':13}}"),
                 StackTraceBean.class);
-        Assert.assertNotNull(bean);
-        Assert.assertNotNull(bean.location);
-        Assert.assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
+        assertNotNull(bean);
+        assertNotNull(bean.location);
+        assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
 
         // and then directly, iff registered
         final ObjectMapper mapper = new ObjectMapper();
@@ -127,7 +128,7 @@ public class JacksonIssue429MyNamesTest {
         final StackTraceElement elem = mapper.readValue(
                 aposToQuotes("{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':13}"),
                 StackTraceElement.class);
-        Assert.assertNotNull(elem);
-        Assert.assertEquals(StackTraceBean.NUM, elem.getLineNumber());
+        assertNotNull(elem);
+        assertEquals(StackTraceBean.NUM, elem.getLineNumber());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/JacksonIssue429Test.java
@@ -25,12 +25,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class JacksonIssue429Test {
 
     @SuppressWarnings("serial")
@@ -73,9 +72,9 @@ public class JacksonIssue429Test {
     public void testStackTraceElementWithCustom() throws Exception {
         // first, via bean that contains StackTraceElement
         final StackTraceBean bean = MAPPER.readValue(aposToQuotes("{'Location':'foobar'}"), StackTraceBean.class);
-        Assert.assertNotNull(bean);
-        Assert.assertNotNull(bean.location);
-        Assert.assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
+        Assertions.assertNotNull(bean);
+        Assertions.assertNotNull(bean.location);
+        Assertions.assertEquals(StackTraceBean.NUM, bean.location.getLineNumber());
 
         // and then directly, iff registered
         final ObjectMapper mapper = new ObjectMapper();
@@ -86,7 +85,7 @@ public class JacksonIssue429Test {
         final StackTraceElement elem = mapper.readValue(
                 aposToQuotes("{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}"),
                 StackTraceElement.class);
-        Assert.assertNotNull(elem);
-        Assert.assertEquals(StackTraceBean.NUM, elem.getLineNumber());
+        Assertions.assertNotNull(elem);
+        Assertions.assertEquals(StackTraceBean.NUM, elem.getLineNumber());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
@@ -22,12 +22,11 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
 public class StackTraceElementMixInTest {
 
     @Test
@@ -53,7 +52,7 @@ public class StackTraceElementMixInTest {
                 new StackTraceElement("package.SomeClass", "someMethod", "SomeClass.java", 123);
         final String s = mapper.writeValueAsString(expected);
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
@@ -76,7 +75,7 @@ public class StackTraceElementMixInTest {
         final String s = this.aposToQuotes(
                 "{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}");
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
@@ -91,6 +90,6 @@ public class StackTraceElementMixInTest {
         final String s = this.aposToQuotes(
                 "{'class':'package.SomeClass','method':'someMethod','file':'SomeClass.java','line':123}");
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/ConcurrentLoggingWithJsonLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/ConcurrentLoggingWithJsonLayoutTest.java
@@ -18,7 +18,7 @@ package org.apache.logging.log4j.core.layout;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -29,29 +29,27 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.AfterClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for LOG4J2-1769.
  *
  * @since 2.8
  */
+@LoggerContextSource("log4j2-json-layout.xml")
 public class ConcurrentLoggingWithJsonLayoutTest {
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule("log4j2-json-layout.xml");
-
     private static final String PATH = "target/test-json-layout.log";
 
-    @AfterClass
+    @AfterAll
     public static void after() {
         new File(PATH).delete();
     }
 
     @Test
-    public void testConcurrentLogging() throws Throwable {
+    public void testConcurrentLogging(final LoggerContext context) throws Throwable {
         final Logger log = context.getLogger(ConcurrentLoggingWithJsonLayoutTest.class);
         final Set<Thread> threads = Collections.synchronizedSet(new HashSet<Thread>());
         final List<Throwable> thrown = Collections.synchronizedList(new ArrayList<Throwable>());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvLogEventLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvLogEventLayoutTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -29,33 +31,28 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link AbstractCsvLayout}.
  *
  * @since 2.4
  */
-@Category(Layouts.Csv.class)
+@Tag("Layouts.Csv")
+@UsingAnyThreadContext
 public class CsvLogEventLayoutTest {
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    @Rule
-    public final ThreadContextRule threadContextRule = new ThreadContextRule();
-
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         ConfigurationFactory.removeConfigurationFactory(cf);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
@@ -123,28 +120,28 @@ public class CsvLogEventLayoutTest {
         final String event0 = list.get(0 + headerOffset);
         final String event1 = list.get(1 + headerOffset);
         final char del = format.getDelimiter();
-        Assert.assertTrue(event0, event0.contains(del + "DEBUG" + del));
+        assertTrue(event0.contains(del + "DEBUG" + del), event0);
         final String quote = del == ',' ? "\"" : "";
-        Assert.assertTrue(event0, event0.contains(del + quote + "one=1, two=2, three=3" + quote + del));
-        Assert.assertTrue(event1, event1.contains(del + "INFO" + del));
+        assertTrue(event0.contains(del + quote + "one=1, two=2, three=3" + quote + del), event0);
+        assertTrue(event1.contains(del + "INFO" + del), event1);
 
         if (hasHeaderSerializer && header == null) {
-            Assert.fail();
+            fail();
         }
         if (!hasHeaderSerializer && header != null) {
-            Assert.fail();
+            fail();
         }
         if (hasFooterSerializer && footer == null) {
-            Assert.fail();
+            fail();
         }
         if (!hasFooterSerializer && footer != null) {
-            Assert.fail();
+            fail();
         }
         if (hasHeaderSerializer) {
-            Assert.assertEquals(list.toString(), header, list.get(0));
+            assertEquals(header, list.get(0), list.toString());
         }
         if (hasFooterSerializer) {
-            Assert.assertEquals(list.toString(), footer, list.get(list.size() - 1));
+            assertEquals(footer, list.get(list.size() - 1), list.toString());
         }
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutAllAsyncTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutAllAsyncTest.java
@@ -21,30 +21,29 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.async.AsyncLoggerContextSelector;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link AbstractCsvLayout} with all loggers async.
  *
  * @since 2.6
  */
-@Category(Layouts.Csv.class)
+@Tag("Layouts.Csv")
 public class CsvParameterLayoutAllAsyncTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerTest.xml");
     }
 
-    @AfterClass
-    public static void afterClass() {
+    @AfterAll
+    public static void afterAll() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutTest.java
@@ -16,7 +16,8 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -30,46 +31,38 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 import org.apache.logging.log4j.message.ObjectArrayMessage;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.logging.log4j.test.junit.UsingThreadContextStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link AbstractCsvLayout}.
  *
  * @since 2.4
  */
-@RunWith(Parameterized.class)
-@Category(Layouts.Csv.class)
+@Tag("Layouts.Csv")
+@UsingThreadContextStack
+@LoggerContextSource(reconfigure = ReconfigurationPolicy.AFTER_EACH)
 public class CsvParameterLayoutTest {
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
+
+    static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            {
-                new LoggerContextRule("csvParamsSync.xml"),
-            },
-            {
-                new LoggerContextRule("csvParamsMixedAsync.xml"),
-            },
+            {"csvParamsSync.xml"}, {"csvParamsMixedAsync.xml"},
         });
     }
 
-    @Rule
-    public final LoggerContextRule init;
+    private final LoggerContext init;
 
-    @Rule
-    public final ThreadContextRule threadContextRule = new ThreadContextRule();
-
-    public CsvParameterLayoutTest(final LoggerContextRule contextRule) {
-        this.init = contextRule;
+    public CsvParameterLayoutTest(final LoggerContext context) {
+        this.init = context;
     }
 
     @Test
@@ -115,20 +108,17 @@ public class CsvParameterLayoutTest {
             // wait until background thread finished processing
             appender.countDownLatch.await(10, TimeUnit.SECONDS);
         }
-        assertEquals(
-                "Background thread did not finish processing: msg count",
-                msgCount,
-                appender.getMessages().size());
+        assertEquals(msgCount, appender.getMessages().size(), "Background thread did not finish processing: msg count");
 
         // don't stop appender until background thread is done
         appender.stop();
 
         final List<String> list = appender.getMessages();
         final char d = layout.getFormat().getDelimiter();
-        Assert.assertEquals("1" + d + "2" + d + "3", list.get(0));
-        Assert.assertEquals("2" + d + "3", list.get(1));
-        Assert.assertEquals("5" + d + "6", list.get(2));
-        Assert.assertEquals("7" + d + "8" + d + "9" + d + "10", list.get(3));
+        assertEquals("1" + d + "2" + d + "3", list.get(0));
+        assertEquals("2" + d + "3", list.get(1));
+        assertEquals("5" + d + "6", list.get(2));
+        assertEquals("7" + d + "8" + d + "9" + d + "10", list.get(3));
     }
 
     private static void removeAppenders(final Logger root) {
@@ -152,27 +142,31 @@ public class CsvParameterLayoutTest {
         root.debug(new ObjectArrayMessage(7, 8, 9, 10));
     }
 
-    @Test
-    public void testLayoutDefaultNormal() throws Exception {
-        final Logger root = this.init.getRootLogger();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLayoutDefaultNormal(String config) throws Exception {
+        final LoggerContext ctx = new LoggerContext(config);
+        final Logger root = ctx.getRootLogger();
         testLayoutNormalApi(root, CsvParameterLayout.createDefaultLayout(), false);
     }
 
-    @Test
-    public void testLayoutDefaultObjectArrayMessage() throws Exception {
-        final Logger root = this.init.getRootLogger();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLayoutDefaultObjectArrayMessage(String config) throws Exception {
+        final LoggerContext ctx = new LoggerContext(config);
+        final Logger root = init.getRootLogger();
         testLayoutNormalApi(root, CsvParameterLayout.createDefaultLayout(), true);
     }
 
-    @Test
-    public void testLayoutTab() throws Exception {
-        final Logger root = this.init.getRootLogger();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLayoutTab(String config) throws Exception {
+        final LoggerContext ctx = new LoggerContext(config);
+        final Logger root = init.getRootLogger();
         testLayoutNormalApi(root, CsvParameterLayout.createLayout(CSVFormat.TDF), true);
     }
 
-    @Test
-    public void testLogJsonArgument() throws InterruptedException {
-        final ListAppender appender = (ListAppender) init.getAppender("List");
+    public void testLogJsonArgument(@Named("list") final ListAppender appender) throws InterruptedException {
         appender.countDownLatch = new CountDownLatch(4);
         appender.clear();
         final Logger logger = (Logger) LogManager.getRootLogger();
@@ -183,15 +177,12 @@ public class CsvParameterLayoutTest {
         if (appender.getMessages().size() < msgCount) {
             appender.countDownLatch.await(5, TimeUnit.SECONDS);
         }
-        assertEquals(
-                "Background thread did not finish processing: msg count",
-                msgCount,
-                appender.getMessages().size());
+        assertEquals(msgCount, appender.getMessages().size(), "Background thread did not finish processing: msg count");
 
         // don't stop appender until background thread is done
         appender.stop();
         final List<String> list = appender.getMessages();
         final String eventStr = list.get(0).toString();
-        Assert.assertTrue(eventStr, eventStr.contains(json));
+        assertTrue(eventStr.contains(json), eventStr);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutMillisTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutMillisTest.java
@@ -16,57 +16,51 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the JsonLayout class with millis.
  */
-@Category(Layouts.Json.class)
+@Tag("Layouts.Json")
+@LoggerContextSource("log4j2-json-layout-timestamp.xml")
 public class JsonLayoutMillisTest {
-
-    private static final String CONFIG = "log4j2-json-layout-timestamp.xml";
-
-    private ListAppender app;
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(CONFIG);
 
     private Logger logger;
 
     private void assertEventCount(final List<LogEvent> events, final int expected) {
-        assertEquals("Incorrect number of events.", expected, events.size());
+        assertEquals(events.size(), expected, "Incorrect number of events.");
     }
 
-    @Before
-    public void before() {
+    @BeforeEach
+    public void before(final LoggerContext context, @Named("List") final ListAppender app) {
         logger = context.getLogger("LayoutTest");
         //
-        app = context.getListAppender("List").clear();
+        app.clear();
     }
 
     @Test
-    public void testTimestamp() {
+    public void testTimestamp(@Named("List") final ListAppender app) {
         logger.info("This is a test message");
         final List<String> message = app.getMessages();
-        assertTrue("No messages", message != null && message.size() > 0);
+        assertTrue(message != null && message.size() > 0, "No messages");
         final String json = message.get(0);
         System.out.println(json);
-        assertNotNull("No JSON message", json);
-        assertTrue("No timestamp", json.contains("\"timeMillis\":"));
-        assertFalse("Instant is present", json.contains("instant:"));
+        assertNotNull(json, "No JSON message");
+        assertTrue(json.contains("\"timeMillis\":"), "No timestamp");
+        assertFalse(json.contains("instant:"), "Instant is present");
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
@@ -18,10 +18,11 @@ package org.apache.logging.log4j.core.layout;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +45,6 @@ import org.apache.logging.log4j.core.jackson.Log4jJsonObjectMapper;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.util.DummyNanoClock;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.core.util.SystemClock;
@@ -56,28 +56,27 @@ import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the JsonLayout class.
  */
-@Category(Layouts.Json.class)
+@Tag("json")
 public class JsonLayoutTest {
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
     private static final String DQUOTE = "\"";
 
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         ConfigurationFactory.removeConfigurationFactory(cf);
         ThreadContext.clearAll();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         ThreadContext.clearAll();
         ConfigurationFactory.setConfigurationFactory(cf);
@@ -92,7 +91,7 @@ public class JsonLayoutTest {
     private void checkAt(final String expected, final int lineIndex, final List<String> list) {
         final String trimedLine = list.get(lineIndex).trim();
         assertTrue(
-                "Incorrect line index " + lineIndex + ": " + Strings.dquote(trimedLine), trimedLine.equals(expected));
+                trimedLine.equals(expected), "Incorrect line index " + lineIndex + ": " + Strings.dquote(trimedLine));
     }
 
     private void checkContains(final String expected, final List<String> list) {
@@ -102,7 +101,7 @@ public class JsonLayoutTest {
                 return;
             }
         }
-        Assert.fail("Cannot find " + expected + " in " + list);
+        fail("Cannot find " + expected + " in " + list);
     }
 
     private void checkMapEntry(
@@ -115,11 +114,11 @@ public class JsonLayoutTest {
         if (contextMapAslist) {
             // {"key":"KEY", "value":"VALUE"}
             final String expected = String.format("{\"key\":\"%s\",\"value\":\"%s\"}", key, value);
-            assertTrue("Cannot find contextMapAslist " + expected + " in " + str, str.contains(expected));
+            assertTrue(str.contains(expected), "Cannot find contextMapAslist " + expected + " in " + str);
         } else {
             // "KEY":"VALUE"
             final String expected = String.format("\"%s\":\"%s\"", key, value);
-            assertTrue("Cannot find contextMap " + expected + " in " + str, str.contains(expected));
+            assertTrue(str.contains(expected), "Cannot find contextMap " + expected + " in " + str);
         }
     }
 
@@ -127,17 +126,17 @@ public class JsonLayoutTest {
         final String propSep = this.toPropertySeparator(compact);
         // {"key":"MDC.B","value":"B_Value"}
         final String expected = String.format("\"%s\"%s\"%s\"", key, propSep, value);
-        assertTrue("Cannot find " + expected + " in " + str, str.contains(expected));
+        assertTrue(str.contains(expected), "Cannot find " + expected + " in " + str);
     }
 
     private void checkPropertyName(final String name, final boolean compact, final String str) {
         final String propSep = this.toPropertySeparator(compact);
-        assertTrue(str, str.contains(DQUOTE + name + DQUOTE + propSep));
+        assertTrue(str.contains(DQUOTE + name + DQUOTE + propSep), str);
     }
 
     private void checkPropertyNameAbsent(final String name, final boolean compact, final String str) {
         final String propSep = this.toPropertySeparator(compact);
-        assertFalse(str, str.contains(DQUOTE + name + DQUOTE + propSep));
+        assertFalse(str.contains(DQUOTE + name + DQUOTE + propSep), str);
     }
 
     private void testAllFeatures(
@@ -167,13 +166,13 @@ public class JsonLayoutTest {
         this.toPropertySeparator(compact);
         if (endOfLine == null) {
             // Just check for \n since \r might or might not be there.
-            assertEquals(str, !compact || eventEol, str.contains("\n"));
+            assertEquals(!compact || eventEol, str.contains("\n"), str);
         } else {
-            assertEquals(str, !compact || eventEol, str.contains(endOfLine));
-            assertEquals(str, compact && eventEol, str.endsWith(endOfLine));
+            assertEquals(!compact || eventEol, str.contains(endOfLine), str);
+            assertEquals(compact && eventEol, str.endsWith(endOfLine), str);
         }
-        assertEquals(str, locationInfo, str.contains("source"));
-        assertEquals(str, includeContext, str.contains("contextMap"));
+        assertEquals(locationInfo, str.contains("source"), str);
+        assertEquals(includeContext, str.contains("contextMap"), str);
 
         final Log4jLogEvent actual = new Log4jJsonObjectMapper(contextMapAslist, includeStacktrace, false, false)
                 .readValue(str, Log4jLogEvent.class);
@@ -374,7 +373,7 @@ public class JsonLayoutTest {
                 .build();
         // @formatter:on
         final String str = layout.toSerializable(expected);
-        assertTrue(str, str.contains("\"loggerName\":\"a.B\""));
+        assertTrue(str.contains("\"loggerName\":\"a.B\""), str);
         final Log4jLogEvent actual =
                 new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
         assertEquals(expected.getLoggerName(), actual.getLoggerName());
@@ -397,8 +396,8 @@ public class JsonLayoutTest {
                 .setConfiguration(ctx.getConfiguration())
                 .build();
         final String str = layout.toSerializable(LogEventFixtures.createLogEvent());
-        assertTrue(str, str.contains("\"KEY1\":\"VALUE1\""));
-        assertTrue(str, str.contains("\"KEY2\":\"" + new JavaLookup().getRuntime() + "\""));
+        assertTrue(str.contains("\"KEY1\":\"VALUE1\""), str);
+        assertTrue(str.contains("\"KEY2\":\"" + new JavaLookup().getRuntime() + "\""), str);
     }
 
     // Test for LOG4J2-2345
@@ -429,10 +428,10 @@ public class JsonLayoutTest {
             mutableLogEvent.initFrom(expected);
             final String str = layout.toSerializable(mutableLogEvent);
             final String expectedMessage = "Testing " + TestObj.TO_STRING_VALUE;
-            assertTrue(str, str.contains("\"message\":\"" + expectedMessage + '"'));
+            assertTrue(str.contains("\"message\":\"" + expectedMessage + '"'), str);
             final Log4jLogEvent actual =
                     new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
-            assertEquals(expectedMessage, actual.getMessage().getFormattedMessage());
+            assertEquals(actual.getMessage().getFormattedMessage(), expectedMessage);
         } finally {
             ReusableMessageFactory.release(message);
         }
@@ -476,7 +475,7 @@ public class JsonLayoutTest {
             assertThat(str, containsString("\"message\":\"" + expectedMessage + '"'));
             final Log4jLogEvent actual =
                     new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
-            assertEquals(expectedMessage, actual.getMessage().getFormattedMessage());
+            assertEquals(actual.getMessage().getFormattedMessage(), expectedMessage);
         } finally {
             ReusableMessageFactory.release(message);
         }
@@ -524,13 +523,13 @@ public class JsonLayoutTest {
     @Test
     public void testStacktraceAsString() throws Exception {
         final String str = prepareJSONForStacktraceTests(true);
-        assertTrue(str, str.contains("\"extendedStackTrace\":\"java.lang.NullPointerException"));
+        assertTrue(str.contains("\"extendedStackTrace\":\"java.lang.NullPointerException"), str);
     }
 
     @Test
     public void testStacktraceAsNonString() throws Exception {
         final String str = prepareJSONForStacktraceTests(false);
-        assertTrue(str, str.contains("\"extendedStackTrace\":["));
+        assertTrue(str.contains("\"extendedStackTrace\":["), str);
     }
 
     private String prepareJSONForStacktraceTests(final boolean stacktraceAsString) {
@@ -548,13 +547,13 @@ public class JsonLayoutTest {
     @Test
     public void testObjectMessageAsJsonString() {
         final String str = prepareJSONForObjectMessageAsJsonObjectTests(1234, false);
-        assertTrue(str, str.contains("\"message\":\"" + this.getClass().getCanonicalName() + "$TestClass@"));
+        assertTrue(str.contains("\"message\":\"" + this.getClass().getCanonicalName() + "$TestClass@"), str);
     }
 
     @Test
     public void testObjectMessageAsJsonObject() {
         final String str = prepareJSONForObjectMessageAsJsonObjectTests(1234, true);
-        assertTrue(str, str.contains("\"message\":{\"value\":1234}"));
+        assertTrue(str.contains("\"message\":{\"value\":1234}"), str);
     }
 
     private String prepareJSONForObjectMessageAsJsonObjectTests(
@@ -582,8 +581,8 @@ public class JsonLayoutTest {
     @Test
     public void testInstantSortsBeforeMessage() {
         final String str = prepareJSONForEventWithTimeAsInstant();
-        assertTrue(str, str.startsWith("{\"instant\":{\"epochSecond\":0,\"nanoOfSecond\":1000000},"));
-        assertTrue(str, str.contains("\"message\":\"message\""));
+        assertTrue(str.startsWith("{\"instant\":{\"epochSecond\":0,\"nanoOfSecond\":1000000},"), str);
+        assertTrue(str.contains("\"message\":\"message\""), str);
     }
 
     private String prepareJSONForEventWithTimeAsInstant() {
@@ -635,7 +634,7 @@ public class JsonLayoutTest {
                 .build();
 
         final String str = layout.toSerializable(LogEventFixtures.createLogEvent());
-        assertFalse(str, str.contains("\"empty\""));
+        assertFalse(str.contains("\"empty\""), str);
     }
 
     /**

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/LogEventFixtures.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/LogEventFixtures.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -104,8 +104,8 @@ class LogEventFixtures {
         assertEquals(expected.getTimeMillis(), actual.getTimeMillis());
         assertEquals(includeSource ? expected.getSource() : null, actual.getSource());
         assertEquals(expected.getThreadName(), actual.getThreadName());
-        assertNotNull("original should have an exception", expected.getThrown());
-        assertNull("exception should not be serialized", actual.getThrown());
+        assertNotNull(expected.getThrown(), "original should have an exception");
+        assertNull(actual.getThrown(), "exception should not be serialized");
         if (includeStacktrace) { // TODO should compare the rest of the ThrowableProxy
             assertEquals(expected.getThrownProxy(), actual.getThrownProxy());
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/SerializedLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/SerializedLayoutTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -39,15 +39,15 @@ import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.test.junit.SerialUtil;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@UsingAnyThreadContext
 public class SerializedLayoutTest {
     private static final String DAT_PATH = "target/test-classes/serializedEvent.dat";
     LoggerContext ctx = LoggerContext.getContext();
@@ -55,17 +55,14 @@ public class SerializedLayoutTest {
 
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    @Rule
-    public final ThreadContextRule threadContextRule = new ThreadContextRule();
-
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
         ctx.reconfigure();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         ConfigurationFactory.removeConfigurationFactory(cf);
     }
@@ -124,8 +121,7 @@ public class SerializedLayoutTest {
         assertFalse(data.isEmpty());
         int i = 0;
         for (final byte[] item : data) {
-            assertEquals(
-                    "Incorrect event", expected[i], SerialUtil.deserialize(item).toString());
+            assertEquals(expected[i], SerialUtil.deserialize(item).toString(), "Incorrect event");
             ++i;
         }
         for (final Appender app : appenders.values()) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/XmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/XmlLayoutTest.java
@@ -16,10 +16,11 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -40,36 +41,31 @@ import org.apache.logging.log4j.core.jackson.Log4jXmlObjectMapper;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link XmlLayout}.
  */
-@Category(Layouts.Xml.class)
+@UsingAnyThreadContext
+@Tag("Layouts.Xml")
 public class XmlLayoutTest {
     private static final String body = "<Message>empty mdc</Message>";
     static ConfigurationFactory cf = new BasicConfigurationFactory();
     private static final String markerTag = "<Marker name=\"EVENT\"/>";
 
-    @Rule
-    public final ThreadContextRule threadContextRule = new ThreadContextRule();
-
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         ConfigurationFactory.removeConfigurationFactory(cf);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
@@ -81,11 +77,11 @@ public class XmlLayoutTest {
     Logger rootLogger = this.ctx.getRootLogger();
 
     private void checkAttribute(final String name, final String value, final boolean compact, final String str) {
-        Assert.assertTrue(str, str.contains(name + "=\"" + value + "\""));
+        assertTrue(str.contains(name + "=\"" + value + "\""), str);
     }
 
     private void checkAttributeName(final String name, final boolean compact, final String str) {
-        Assert.assertTrue(str, str.contains(name + "=\""));
+        assertTrue(str.contains(name + "=\""), str);
     }
 
     private void checkContains(final String expected, final List<String> list) {
@@ -95,12 +91,12 @@ public class XmlLayoutTest {
                 return;
             }
         }
-        Assert.fail("Cannot find " + expected + " in " + list);
+        fail("Cannot find " + expected + " in " + list);
     }
 
     private void checkElement(final String key, final String value, final boolean compact, final String str) {
         // <item key="MDC.A" value="A_Value"/>
-        assertTrue(str, str.contains(String.format("<item key=\"%s\" value=\"%s\"/>", key, value)));
+        assertTrue(str.contains(String.format("<item key=\"%s\" value=\"%s\"/>", key, value)), str);
     }
 
     private void checkElementName(
@@ -113,15 +109,15 @@ public class XmlLayoutTest {
         // start
         final String startStr = withAttributes ? "<" + name + " " : "<" + name + ">";
         final int startPos = str.indexOf(startStr);
-        Assert.assertTrue(str, startPos >= 0);
+        assertTrue(startPos >= 0, str);
         // end
         final String endStr = withChildren ? "</" + name + ">" : "/>";
         final int endPos = str.indexOf(endStr, startPos + startStr.length());
-        Assert.assertTrue(str, endPos >= 0);
+        assertTrue(endPos >= 0, str);
     }
 
     private void checkElementNameAbsent(final String name, final boolean compact, final String str) {
-        Assert.assertFalse(str.contains("<" + name));
+        assertFalse(str.contains("<" + name));
     }
 
     /**
@@ -149,9 +145,9 @@ public class XmlLayoutTest {
                 .build();
         final String str = layout.toSerializable(expected);
         // System.out.println(str);
-        assertEquals(str, !compact, str.contains("\n"));
-        assertEquals(str, includeSource, str.contains("<Source"));
-        assertEquals(str, includeContext, str.contains("<ContextMap"));
+        assertEquals(!compact, str.contains("\n"), str);
+        assertEquals(includeSource, str.contains("<Source"), str);
+        assertEquals(includeContext, str.contains("<ContextMap"), str);
         final Log4jLogEvent actual = new Log4jXmlObjectMapper().readValue(str, Log4jLogEvent.class);
         LogEventFixtures.assertEqualLogEvents(expected, actual, includeSource, includeContext, includeStacktrace);
         if (includeContext) {
@@ -162,15 +158,15 @@ public class XmlLayoutTest {
         //
         assertNull(actual.getThrown());
         // check some attrs
-        assertTrue(str, str.contains("loggerFqcn=\"f.q.c.n\""));
-        assertTrue(str, str.contains("loggerName=\"a.B\""));
+        assertTrue(str.contains("loggerFqcn=\"f.q.c.n\""), str);
+        assertTrue(str.contains("loggerName=\"a.B\""), str);
         // make sure short names are used
-        assertTrue(str, str.contains("<Event "));
+        assertTrue(str.contains("<Event "), str);
         if (includeStacktrace) {
-            assertTrue(str, str.contains("class="));
-            assertTrue(str, str.contains("method="));
-            assertTrue(str, str.contains("file="));
-            assertTrue(str, str.contains("line="));
+            assertTrue(str.contains("class="), str);
+            assertTrue(str.contains("method="), str);
+            assertTrue(str.contains("file="), str);
+            assertTrue(str.contains("line="), str);
         }
         //
         // make sure the names we want are used
@@ -281,8 +277,8 @@ public class XmlLayoutTest {
         final List<String> list = appender.getMessages();
 
         final String string = list.get(0);
-        assertTrue("Incorrect header: " + string, string.equals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
-        assertTrue("Incorrect footer", list.get(list.size() - 1).equals("</Events>"));
+        assertTrue(string.equals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"), "Incorrect header: " + string);
+        assertTrue(list.get(list.size() - 1).equals("</Events>"), "Incorrect footer");
         this.checkContains("loggerFqcn=\"" + AbstractLogger.class.getName() + "\"", list);
         this.checkContains("level=\"DEBUG\"", list);
         this.checkContains(">starting mdc pattern test</Message>", list);
@@ -316,7 +312,7 @@ public class XmlLayoutTest {
                 .setTimeMillis(1)
                 .build();
         final String str = layout.toSerializable(event);
-        assertTrue(str, str.contains("loggerName=\"a.B\""));
+        assertTrue(str.contains("loggerName=\"a.B\""), str);
     }
 
     @Test
@@ -332,8 +328,8 @@ public class XmlLayoutTest {
                 .setConfiguration(ctx.getConfiguration())
                 .build();
         final String str = layout.toSerializable(LogEventFixtures.createLogEvent());
-        assertTrue(str, str.contains("<KEY1>VALUE1</KEY1>"));
-        assertTrue(str, str.contains("<KEY2>" + new JavaLookup().getRuntime() + "</KEY2>"));
+        assertTrue(str.contains("<KEY1>VALUE1</KEY1>"), str);
+        assertTrue(str.contains("<KEY2>" + new JavaLookup().getRuntime() + "</KEY2>"), str);
     }
 
     @Test
@@ -354,13 +350,13 @@ public class XmlLayoutTest {
     @Test
     public void testStacktraceAsString() throws Exception {
         final String str = prepareXMLForStacktraceTests(true);
-        assertTrue(str, str.contains("<ExtendedStackTrace>java.lang.NullPointerException"));
+        assertTrue(str.contains("<ExtendedStackTrace>java.lang.NullPointerException"), str);
     }
 
     @Test
     public void testStacktraceAsNonString() throws Exception {
         final String str = prepareXMLForStacktraceTests(false);
-        assertTrue(str, str.contains("<ExtendedStackTrace><ExtendedStackTraceItem"));
+        assertTrue(str.contains("<ExtendedStackTrace><ExtendedStackTraceItem"), str);
     }
 
     private String prepareXMLForStacktraceTests(final boolean stacktraceAsString) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/YamlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/YamlLayoutTest.java
@@ -17,11 +17,12 @@
 package org.apache.logging.log4j.core.layout;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,31 +42,29 @@ import org.apache.logging.log4j.core.jackson.Log4jYamlObjectMapper;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the YamlLayout class.
  */
-@Category(Layouts.Yaml.class)
+@Tag("Layouts.Yaml")
 public class YamlLayoutTest {
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
         ConfigurationFactory.removeConfigurationFactory(cf);
         ThreadContext.clearAll();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
         ThreadContext.clearAll();
         ConfigurationFactory.setConfigurationFactory(cf);
@@ -80,7 +79,7 @@ public class YamlLayoutTest {
     private void checkAt(final String expected, final int lineIndex, final List<String> list) {
         final String trimedLine = list.get(lineIndex).trim();
         assertTrue(
-                "Incorrect line index " + lineIndex + ": " + Strings.dquote(trimedLine), trimedLine.equals(expected));
+                trimedLine.equals(expected), "Incorrect line index " + lineIndex + ": " + Strings.dquote(trimedLine));
     }
 
     private void checkContains(final String expected, final List<String> list) {
@@ -90,14 +89,14 @@ public class YamlLayoutTest {
                 return;
             }
         }
-        Assert.fail("Cannot find " + expected + " in " + list);
+        fail("Cannot find " + expected + " in " + list);
     }
 
     private void checkMapEntry(final String key, final String value, final boolean compact, final String str) {
         // "name":"value"
         // final String expected = String.format("- key: \"%s\"\n  value: \"%s\"", key, value);
         final String expected = String.format("%s: \"%s\"", key, value);
-        assertTrue("Cannot find " + expected + " in " + str, str.contains(expected));
+        assertTrue(str.contains(expected), "Cannot find " + expected + " in " + str);
     }
 
     private void checkProperty(
@@ -105,18 +104,18 @@ public class YamlLayoutTest {
         final String propSep = this.toPropertySeparator(compact, isValue);
         // {"key":"MDC.B","value":"B_Value"}
         final String expected = String.format("%s%s\"%s\"", key, propSep, value);
-        assertTrue("Cannot find " + expected + " in " + str, str.contains(expected));
+        assertTrue(str.contains(expected), "Cannot find " + expected + " in " + str);
     }
 
     private void checkPropertyName(final String name, final boolean compact, final String str, final boolean isValue) {
         final String propSep = this.toPropertySeparator(compact, isValue);
-        assertTrue(str, str.contains(name + propSep));
+        assertTrue(str.contains(name + propSep), str);
     }
 
     private void checkPropertyNameAbsent(
             final String name, final boolean compact, final String str, final boolean isValue) {
         final String propSep = this.toPropertySeparator(compact, isValue);
-        assertFalse(str, str.contains(name + propSep));
+        assertFalse(str.contains(name + propSep), str);
     }
 
     private void testAllFeatures(
@@ -137,9 +136,9 @@ public class YamlLayoutTest {
         final String str = layout.toSerializable(expected);
         // System.out.println(str);
         // Just check for \n since \r might or might not be there.
-        assertEquals(str, !compact || eventEol, str.contains("\n"));
-        assertEquals(str, includeSource, str.contains("source"));
-        assertEquals(str, includeContext, str.contains("contextMap"));
+        assertEquals(!compact || eventEol, str.contains("\n"), str);
+        assertEquals(includeSource, str.contains("source"), str);
+        assertEquals(includeContext, str.contains("contextMap"), str);
         final Log4jLogEvent actual = new Log4jYamlObjectMapper(contextMapAslist, includeStacktrace, false)
                 .readValue(str, Log4jLogEvent.class);
         LogEventFixtures.assertEqualLogEvents(expected, actual, includeSource, includeContext, includeStacktrace);
@@ -308,7 +307,7 @@ public class YamlLayoutTest {
                 .setTimeMillis(1)
                 .build();
         final String str = layout.toSerializable(expected);
-        assertTrue(str, str.contains("loggerName: \"a.B\""));
+        assertTrue(str.contains("loggerName: \"a.B\""), str);
         final Log4jLogEvent actual = new Log4jYamlObjectMapper(false, true, false).readValue(str, Log4jLogEvent.class);
         assertEquals(expected.getLoggerName(), actual.getLoggerName());
         assertEquals(expected, actual);
@@ -360,13 +359,13 @@ public class YamlLayoutTest {
     @Test
     public void testStacktraceAsString() throws Exception {
         final String str = prepareYAMLForStacktraceTests(true);
-        assertTrue(str, str.contains("extendedStackTrace: \"java.lang.NullPointerException"));
+        assertTrue(str.contains("extendedStackTrace: \"java.lang.NullPointerException"), str);
     }
 
     @Test
     public void testStacktraceAsNonString() throws Exception {
         final String str = prepareYAMLForStacktraceTests(false);
-        assertTrue(str, str.contains("extendedStackTrace:\n    - "));
+        assertTrue(str.contains("extendedStackTrace:\n    - "), str);
     }
 
     private String prepareYAMLForStacktraceTests(final boolean stacktraceAsString) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/EmbeddedLdapExtension.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/EmbeddedLdapExtension.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.lookup;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.LDAPException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.net.URLDecoder;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.LdapContext;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.zapodot.junit.ldap.internal.jndi.ContextProxyFactory;
+
+public class EmbeddedLdapExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private static final String LDIF_FILENAME = "JndiRestrictedLookup.ldif";
+    private static final String JAVA_RT_CONTROL_FACTORY = "com.sun.jndi.ldap.DefaultResponseControlFactory";
+    private static final String JAVA_RT_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    public static final String DEFAULT_BIND_DSN = "cn=Directory manager";
+    public static final String DEFAULT_BIND_CREDENTIALS = "password";
+    public static final String LDAP_SERVER_LISTENER_NAME = "test-listener";
+
+    private String domainDsn;
+    private InMemoryDirectoryServer ldapServer = null;
+    private InitialDirContext initialDirContext = null;
+
+    public EmbeddedLdapExtension(String domainDsn) {
+        this.domainDsn = domainDsn;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        startLdapServer();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        shutdownLdapServer();
+    }
+
+    void startLdapServer() throws LDAPException, NamingException, UnsupportedEncodingException {
+        InMemoryDirectoryServerConfig config = getConfig();
+
+        ldapServer = new InMemoryDirectoryServer(config);
+        String path = Resources.getResource(LDIF_FILENAME).getPath();
+        ldapServer.importFromLDIF(false, URLDecoder.decode(path, Charsets.UTF_8.name()));
+        ldapServer.startListening();
+
+        initialDirContext = buildInitialDirContext();
+    }
+
+    private InMemoryDirectoryServerConfig getConfig() throws LDAPException {
+        String[] domainDsnArray = new String[] {this.domainDsn};
+        InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(domainDsnArray);
+
+        config.addAdditionalBindCredentials(DEFAULT_BIND_DSN, DEFAULT_BIND_CREDENTIALS);
+
+        InetAddress bindAddress = InetAddress.getLoopbackAddress();
+        Integer bindPort = 0;
+        InMemoryListenerConfig listenerConfig =
+                InMemoryListenerConfig.createLDAPConfig(LDAP_SERVER_LISTENER_NAME, bindAddress, bindPort, null);
+        config.setListenerConfigs(listenerConfig);
+
+        config.setSchema(null);
+
+        return config;
+    }
+
+    private InitialDirContext buildInitialDirContext() throws NamingException {
+        Hashtable<String, String> environment = new Hashtable<>();
+
+        environment.put(LdapContext.CONTROL_FACTORIES, JAVA_RT_CONTROL_FACTORY);
+        environment.put(Context.INITIAL_CONTEXT_FACTORY, JAVA_RT_CONTEXT_FACTORY);
+
+        environment.put(
+                Context.PROVIDER_URL,
+                String.format("ldap://%s:%s", ldapServer.getListenAddress().getHostName(), embeddedServerPort()));
+
+        return new InitialDirContext(environment);
+    }
+
+    void shutdownLdapServer() {
+        try {
+            if (initialDirContext != null) {
+                initialDirContext.close();
+            }
+        } catch (NamingException e) {
+            // logger.info("Could not close initial context, forcing server shutdown anyway", e);
+        } finally {
+            ldapServer.shutDown(true);
+        }
+    }
+
+    int embeddedServerPort() {
+        return ldapServer.getListenPort();
+    }
+
+    Context context() {
+        return ContextProxyFactory.asDelegatingContext(initialDirContext);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
@@ -17,9 +17,9 @@
 package org.apache.logging.log4j.core.lookup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -39,12 +39,12 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerContextAware;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.test.junit.JndiRule;
+import org.apache.logging.log4j.core.test.junit.JndiExtension;
 import org.apache.logging.log4j.message.StringMapMessage;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.ExternalResource;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junitpioneer.jupiter.Issue;
 
 /**
@@ -60,24 +60,28 @@ public class InterpolatorTest {
     private static final String TEST_CONTEXT_RESOURCE_NAME = "logging/context-name";
     private static final String TEST_CONTEXT_NAME = "app-1";
 
-    @ClassRule
-    public static final RuleChain RULES = RuleChain.outerRule(new ExternalResource() {
-                @Override
-                protected void before() throws Throwable {
-                    System.setProperty(TESTKEY, TESTVAL);
-                    System.setProperty(TESTKEY2, TESTVAL);
-                    System.setProperty("log4j2.enableJndiLookup", "true");
-                }
+    @RegisterExtension
+    public final JndiExtension ext = new JndiExtension(createBindings());
 
-                @Override
-                protected void after() {
-                    System.clearProperty(TESTKEY);
-                    System.clearProperty(TESTKEY2);
-                    System.clearProperty("log4j2.enableJndiLookup");
-                }
-            })
-            .around(new JndiRule(
-                    JndiLookup.CONTAINER_JNDI_RESOURCE_PATH_PREFIX + TEST_CONTEXT_RESOURCE_NAME, TEST_CONTEXT_NAME));
+    @BeforeAll
+    public static void beforeAll() {
+        System.setProperty(TESTKEY, TESTVAL);
+        System.setProperty(TESTKEY2, TESTVAL);
+        System.setProperty("log4j2.enableJndiLookup", "true");
+    }
+
+    private Map<String, Object> createBindings() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(JndiLookup.CONTAINER_JNDI_RESOURCE_PATH_PREFIX + TEST_CONTEXT_RESOURCE_NAME, TEST_CONTEXT_NAME);
+        return map;
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        System.clearProperty(TESTKEY);
+        System.clearProperty(TESTKEY2);
+        System.clearProperty("log4j2.enableJndiLookup");
+    }
 
     @Test
     public void testGetDefaultLookup() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
@@ -17,12 +17,12 @@
 package org.apache.logging.log4j.core.lookup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
 import java.text.SimpleDateFormat;
@@ -41,10 +41,10 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.test.junit.JndiExtension;
 import org.apache.logging.log4j.message.StringMapMessage;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.Issue;
 
 /**

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiDisabledLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiDisabledLookupTest.java
@@ -18,7 +18,7 @@ package org.apache.logging.log4j.core.lookup;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JndiDisabledLookupTest

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiLookupTest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.logging.log4j.core.test.junit.JndiRule;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.JndiExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * JndiLookupTest
@@ -40,11 +40,11 @@ public class JndiLookupTest {
     private static final String TEST_STRINGS_NAME = "string-collection";
     private static final Collection<String> TEST_STRINGS_COLLECTION = Arrays.asList("one", "two", "three");
 
-    @Rule
-    public JndiRule jndiRule = new JndiRule(createBindings());
+    @RegisterExtension
+    public final JndiExtension ext = new JndiExtension(createBindings());
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty("log4j2.enableJndiLookup", "true");
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import javax.naming.Context;
@@ -25,11 +25,9 @@ import javax.naming.Reference;
 import javax.naming.Referenceable;
 import javax.naming.StringRefAddr;
 import org.apache.logging.log4j.message.Message;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.zapodot.junit.ldap.EmbeddedLdapRule;
-import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * JndiLookupTest
@@ -40,26 +38,22 @@ public class JndiRestrictedLookupTest {
     private static final String RESOURCE = "JndiExploit";
     private static final String TEST_STRING = "TestString";
     private static final String TEST_MESSAGE = "TestMessage";
-    private static final String LEVEL = "TestLevel";
     private static final String DOMAIN_DSN = "dc=apache,dc=org";
     private static final String DOMAIN = "apache.org";
 
-    @Rule
-    public EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder.newInstance()
-            .usingDomainDsn(DOMAIN_DSN)
-            .importingLdifs("JndiRestrictedLookup.ldif")
-            .build();
+    @RegisterExtension
+    private EmbeddedLdapExtension ldapExtension = new EmbeddedLdapExtension(DOMAIN_DSN);
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty("log4j2.enableJndiLookup", "true");
     }
 
     @Test
     @SuppressWarnings("BanJNDI")
     public void testBadUriLookup() throws Exception {
-        final int port = embeddedLdapRule.embeddedServerPort();
-        final Context context = embeddedLdapRule.context();
+        final int port = ldapExtension.embeddedServerPort();
+        final Context context = ldapExtension.context();
         context.bind("cn=" + RESOURCE + "," + DOMAIN_DSN, new Fruit("Test Message"));
         final StrLookup lookup = new JndiLookup();
         final String result = lookup.lookup(
@@ -72,8 +66,8 @@ public class JndiRestrictedLookupTest {
     @Test
     @SuppressWarnings("BanJNDI")
     public void testReferenceLookup() throws Exception {
-        final int port = embeddedLdapRule.embeddedServerPort();
-        final Context context = embeddedLdapRule.context();
+        final int port = ldapExtension.embeddedServerPort();
+        final Context context = ldapExtension.context();
         context.bind("cn=" + RESOURCE + "," + DOMAIN_DSN, new Fruit("Test Message"));
         final StrLookup lookup = new JndiLookup();
         final String result = lookup.lookup(LDAP_URL + port + "/" + "cn=" + RESOURCE + "," + DOMAIN_DSN);
@@ -85,8 +79,8 @@ public class JndiRestrictedLookupTest {
     @Test
     @SuppressWarnings("BanJNDI")
     public void testSerializableLookup() throws Exception {
-        final int port = embeddedLdapRule.embeddedServerPort();
-        final Context context = embeddedLdapRule.context();
+        final int port = ldapExtension.embeddedServerPort();
+        final Context context = ldapExtension.context();
         context.bind("cn=" + TEST_STRING + "," + DOMAIN_DSN, "Test Message");
         final StrLookup lookup = new JndiLookup();
         final String result = lookup.lookup(LDAP_URL + port + "/" + "cn=" + TEST_STRING + "," + DOMAIN_DSN);
@@ -98,8 +92,8 @@ public class JndiRestrictedLookupTest {
     @Test
     @SuppressWarnings("BanJNDI")
     public void testBadSerializableLookup() throws Exception {
-        final int port = embeddedLdapRule.embeddedServerPort();
-        final Context context = embeddedLdapRule.context();
+        final int port = ldapExtension.embeddedServerPort();
+        final Context context = ldapExtension.context();
         context.bind("cn=" + TEST_MESSAGE + "," + DOMAIN_DSN, new SerializableMessage("Test Message"));
         final StrLookup lookup = new JndiLookup();
         final String result = lookup.lookup(LDAP_URL + port + "/" + "cn=" + TEST_MESSAGE + "," + DOMAIN_DSN);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/JsonLogEventParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/JsonLogEventParserTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.logging.log4j.core.parser;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JsonLogEventParserTest extends LogEventParserTest {
 
@@ -71,7 +73,7 @@ public class JsonLogEventParserTest extends LogEventParserTest {
             + "  }\n"
             + "}";
 
-    @Before
+    @BeforeEach
     public void setup() {
         parser = new JsonLogEventParser();
     }
@@ -82,19 +84,19 @@ public class JsonLogEventParserTest extends LogEventParserTest {
         assertLogEvent(logEvent);
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringEmpty() throws ParseException {
-        parser.parseFrom("");
+        assertThrows(ParseException.class, () -> parser.parseFrom(""));
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringInvalidJson() throws ParseException {
-        parser.parseFrom("foobar");
+        assertThrows(ParseException.class, () -> parser.parseFrom("foobar"));
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringJsonArray() throws ParseException {
-        parser.parseFrom("[]");
+        assertThrows(ParseException.class, () -> parser.parseFrom("[]"));
     }
 
     @Test
@@ -102,9 +104,9 @@ public class JsonLogEventParserTest extends LogEventParserTest {
         parser.parseFrom("{}");
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringWrongPropertyType() throws ParseException {
-        parser.parseFrom("{\"threadId\":\"foobar\"}");
+        assertThrows(ParseException.class, () -> parser.parseFrom("{\"threadId\":\"foobar\"}"));
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/LogEventParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/LogEventParserTest.java
@@ -19,8 +19,8 @@ package org.apache.logging.log4j.core.parser;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import org.apache.logging.log4j.Level;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/XmlLogEventParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/XmlLogEventParserTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.logging.log4j.core.parser;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class XmlLogEventParserTest extends LogEventParserTest {
 
@@ -72,7 +74,7 @@ public class XmlLogEventParserTest extends LogEventParserTest {
                     + "  </Thrown>\n"
                     + "</Event>";
 
-    @Before
+    @BeforeEach
     public void setup() {
         parser = new XmlLogEventParser();
     }
@@ -83,14 +85,14 @@ public class XmlLogEventParserTest extends LogEventParserTest {
         assertLogEvent(logEvent);
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringEmpty() throws ParseException {
-        parser.parseFrom("");
+        assertThrows(ParseException.class, () -> parser.parseFrom(""));
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringInvalidXml() throws ParseException {
-        parser.parseFrom("foobar");
+        assertThrows(ParseException.class, () -> parser.parseFrom("foobar"));
     }
 
     @Test
@@ -98,9 +100,11 @@ public class XmlLogEventParserTest extends LogEventParserTest {
         parser.parseFrom("<Event></Event>");
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringWrongPropertyType() throws ParseException {
-        parser.parseFrom("<Event><Instant epochSecond=\"bar\">foobar</Instant></Event>");
+        assertThrows(
+                ParseException.class,
+                () -> parser.parseFrom("<Event><Instant epochSecond=\"bar\">foobar</Instant></Event>"));
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/YamlLogEventParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/parser/YamlLogEventParserTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.logging.log4j.core.parser;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class YamlLogEventParserTest extends LogEventParserTest {
 
@@ -67,7 +69,7 @@ public class YamlLogEventParserTest extends LogEventParserTest {
             + " file: \"Main.java\"\n"
             + " line: 29";
 
-    @Before
+    @BeforeEach
     public void setup() {
         parser = new YamlLogEventParser();
     }
@@ -78,14 +80,14 @@ public class YamlLogEventParserTest extends LogEventParserTest {
         assertLogEvent(logEvent);
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringEmpty() throws ParseException {
-        parser.parseFrom("");
+        assertThrows(ParseException.class, () -> parser.parseFrom(""));
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringInvalidYaml() throws ParseException {
-        parser.parseFrom("foobar");
+        assertThrows(ParseException.class, () -> parser.parseFrom("foobar"));
     }
 
     @Test
@@ -98,9 +100,9 @@ public class YamlLogEventParserTest extends LogEventParserTest {
         parser.parseFrom("---\ntimeMillis: \"foobar\"\n");
     }
 
-    @Test(expected = ParseException.class)
+    @Test()
     public void testStringWrongPropertyType() throws ParseException {
-        parser.parseFrom("---\nthreadId: \"foobar\"\n");
+        assertThrows(ParseException.class, () -> parser.parseFrom("---\nthreadId: \"foobar\"\n"));
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
@@ -16,31 +16,19 @@
  */
 package org.apache.logging.log4j.core.pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *  Unit tests for {@link NameAbbreviator} which abbreviates dot-delimited strings such as logger and class names.
  */
-@RunWith(Parameterized.class)
 public class NameAbbreviatorTest {
 
-    private final String pattern;
-    private final String expected;
-
-    public NameAbbreviatorTest(final String pattern, final String expected) {
-        this.pattern = pattern;
-        this.expected = expected;
-    }
-
-    @Parameterized.Parameters(name = "pattern=\"{0}\", expected={1}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
+    public static Stream<Object[]> data() {
+        return Stream.of(new Object[][] {
             // { pattern, expected }
             {"0", "NameAbbreviatorTest"},
             {"1", "NameAbbreviatorTest"},
@@ -56,18 +44,20 @@ public class NameAbbreviatorTest {
         });
     }
 
-    @Test
-    public void testAbbreviatorPatterns() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatterns(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final StringBuilder destination = new StringBuilder();
         abbreviator.abbreviate(this.getClass().getName(), destination);
         final String actual = destination.toString();
         assertEquals(expected, actual);
     }
 
-    @Test
-    public void testAbbreviatorPatternsAppendLongPrefix() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatternsAppendLongPrefix(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final String PREFIX = "some random text big enough to be larger than abbreviated string ";
         final StringBuilder destination = new StringBuilder(PREFIX);
         abbreviator.abbreviate(this.getClass().getName(), destination);
@@ -75,9 +65,10 @@ public class NameAbbreviatorTest {
         assertEquals(PREFIX + expected, actual);
     }
 
-    @Test
-    public void testAbbreviatorPatternsAppend() throws Exception {
-        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(this.pattern);
+    @ParameterizedTest(name = "pattern=\"{0}\", expected={1}")
+    @MethodSource("data")
+    public void testAbbreviatorPatternsAppend(String pattern, String expected) throws Exception {
+        final NameAbbreviator abbreviator = NameAbbreviator.getAbbreviator(pattern);
         final String PREFIX = "some random text";
         final StringBuilder destination = new StringBuilder(PREFIX);
         abbreviator.abbreviate(this.getClass().getName(), destination);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
@@ -16,25 +16,25 @@
  */
 package org.apache.logging.log4j.core.selector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public final class BasicContextSelectorTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, BasicContextSelector.class.getName());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/SourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/SourceTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.core.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.MalformedURLException;


### PR DESCRIPTION
[A clear and concise description of what the pull request is for along with a reference to the associated issue IDs, if they exist.]

- [ ] DefaultRouteScriptAppenderTest.java (Difficult!)
- [x] JsonRoutingAppender2Test.java
- [x] JsonRoutingAppenderTest
- [x] PropertiesRoutingAppenderTest
- [ ] RoutesScriptAppenderTest (Difficult!)
- [x] RoutingAppender2767Test (Easy)
- [x] RoutingAppender3350Test (Easy)
- [x] RoutingAppenderKeyLookupEvaluationTest (Middle)
- [x] RoutingAppenderTest (Easy)
- [ ] RoutingAppenderWithJndiTest (Middle)
- [ ] RoutingAppenderWithPurgingTest (Middle)
- [x] RoutingDefaultAppenderTest (Easy)

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
